### PR TITLE
Suggest installing all skills when using `npx skills`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,14 +39,14 @@ Skills for writing quality Pulumi programs, components, automation, and secrets 
 Install all skills:
 
 ```bash
-npx skills add pulumi/agent-skills
+npx skills add pulumi/agent-skills --skill '*'
 ```
 
 Or install individual plugin groups:
 
 ```bash
-npx skills add pulumi/agent-skills/migration      # 4 migration skills
-npx skills add pulumi/agent-skills/authoring      # 4 authoring skills
+npx skills add pulumi/agent-skills/migration --skill '*'     # 4 migration skills
+npx skills add pulumi/agent-skills/authoring --skill '*'     # 4 authoring skills
 ```
 
 This works with Claude Code, Cursor, Copilot, Codex, and other agent tools.

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ Write quality Pulumi programs, components, automation, and secrets management:
 Install all skills:
 
 ```bash
-npx skills add pulumi/agent-skills
+npx skills add pulumi/agent-skills --skill '*'
 ```
 
 Or install individual plugin groups:
 
 ```bash
-npx skills add pulumi/agent-skills/migration      # 4 migration skills
-npx skills add pulumi/agent-skills/authoring      # 4 authoring skills
+npx skills add pulumi/agent-skills/migration --skill '*'     # 4 migration skills
+npx skills add pulumi/agent-skills/authoring --skill '*'     # 4 authoring skills
 ```
 
 This works with Claude Code, Cursor, Copilot, Codex, and other agent tools.


### PR DESCRIPTION
Otherwise it is cumbersome to select all skills in the wizard. It is still useful to let users select which agents to target in the wizard.

Wildcard support was recently added in:
https://github.com/vercel-labs/skills/pull/191