### PR TITLE
Add OpenAI metadata for all Pulumi skills

### DIFF
--- a/authoring/skills/pulumi-automation-api/agents/openai.yaml
+++ b/authoring/skills/pulumi-automation-api/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: Pulumi Automation API
+  short_description: Orchestrate Pulumi stacks via Automation API
+  default_prompt: Use $pulumi-automation-api to design or improve this Automation API workflow.

--- a/authoring/skills/pulumi-automation-api/agents/openai.yaml
+++ b/authoring/skills/pulumi-automation-api/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: Pulumi Automation API
-  short_description: Orchestrate Pulumi stacks via Automation API
-  default_prompt: Use $pulumi-automation-api to design or improve this Automation API workflow.
+  display_name: "Pulumi Automation API"
+  short_description: "Orchestrate Pulumi stacks via Automation API"
+  default_prompt: "Use $pulumi-automation-api to design or improve this Automation API workflow."

--- a/authoring/skills/pulumi-best-practices/agents/openai.yaml
+++ b/authoring/skills/pulumi-best-practices/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: Pulumi Best Practices
+  short_description: Best practices for robust Pulumi programs
+  default_prompt: Use $pulumi-best-practices to apply reliable Pulumi coding patterns to this task.

--- a/authoring/skills/pulumi-best-practices/agents/openai.yaml
+++ b/authoring/skills/pulumi-best-practices/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: Pulumi Best Practices
-  short_description: Best practices for robust Pulumi programs
-  default_prompt: Use $pulumi-best-practices to apply reliable Pulumi coding patterns to this task.
+  display_name: "Pulumi Best Practices"
+  short_description: "Best practices for robust Pulumi programs"
+  default_prompt: "Use $pulumi-best-practices to apply reliable Pulumi coding patterns to this task."

--- a/authoring/skills/pulumi-component/agents/openai.yaml
+++ b/authoring/skills/pulumi-component/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: Pulumi Component
+  short_description: Author reusable Pulumi ComponentResource classes
+  default_prompt: Use $pulumi-component to design or refine this Pulumi ComponentResource implementation.

--- a/authoring/skills/pulumi-component/agents/openai.yaml
+++ b/authoring/skills/pulumi-component/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: Pulumi Component
-  short_description: Author reusable Pulumi ComponentResource classes
-  default_prompt: Use $pulumi-component to design or refine this Pulumi ComponentResource implementation.
+  display_name: "Pulumi Component"
+  short_description: "Author reusable Pulumi ComponentResource classes"
+  default_prompt: "Use $pulumi-component to design or refine this Pulumi ComponentResource implementation."

--- a/authoring/skills/pulumi-esc/agents/openai.yaml
+++ b/authoring/skills/pulumi-esc/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: Pulumi ESC
-  short_description: Manage Pulumi environments, secrets, and config
-  default_prompt: Use $pulumi-esc to set up or troubleshoot Pulumi ESC environments and secrets.
+  display_name: "Pulumi ESC"
+  short_description: "Manage Pulumi environments, secrets, and config"
+  default_prompt: "Use $pulumi-esc to set up or troubleshoot Pulumi ESC environments and secrets."

--- a/authoring/skills/pulumi-esc/agents/openai.yaml
+++ b/authoring/skills/pulumi-esc/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: Pulumi ESC
+  short_description: Manage Pulumi environments, secrets, and config
+  default_prompt: Use $pulumi-esc to set up or troubleshoot Pulumi ESC environments and secrets.

--- a/migration/skills/cloudformation-to-pulumi/agents/openai.yaml
+++ b/migration/skills/cloudformation-to-pulumi/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CloudFormation to Pulumi Migration"
+  short_description: "Convert CloudFormation stacks/templates to Pulumi."
+  default_prompt: "Use $cloudformation-to-pulumi to migrate an AWS CloudFormation stack or template to Pulumi."

--- a/migration/skills/cloudformation-to-pulumi/agents/openai.yaml
+++ b/migration/skills/cloudformation-to-pulumi/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "CloudFormation to Pulumi Migration"
-  short_description: "Convert CloudFormation stacks/templates to Pulumi."
+  short_description: "Convert CloudFormation stacks/templates to Pulumi"
   default_prompt: "Use $cloudformation-to-pulumi to migrate an AWS CloudFormation stack or template to Pulumi."

--- a/migration/skills/pulumi-arm-to-pulumi/agents/openai.yaml
+++ b/migration/skills/pulumi-arm-to-pulumi/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ARM/Bicep to Pulumi Migration"
+  short_description: "Convert Azure ARM or Bicep templates to Pulumi."
+  default_prompt: "Use $pulumi-arm-to-pulumi to migrate Azure ARM or Bicep templates and imports to Pulumi."

--- a/migration/skills/pulumi-arm-to-pulumi/agents/openai.yaml
+++ b/migration/skills/pulumi-arm-to-pulumi/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "ARM/Bicep to Pulumi Migration"
-  short_description: "Convert Azure ARM or Bicep templates to Pulumi."
+  short_description: "Convert Azure ARM or Bicep templates to Pulumi"
   default_prompt: "Use $pulumi-arm-to-pulumi to migrate Azure ARM or Bicep templates and imports to Pulumi."

--- a/migration/skills/pulumi-cdk-to-pulumi/agents/openai.yaml
+++ b/migration/skills/pulumi-cdk-to-pulumi/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "AWS CDK to Pulumi Migration"
-  short_description: "Convert an AWS CDK application to Pulumi."
+  short_description: "Convert an AWS CDK application to Pulumi"
   default_prompt: "Use $pulumi-cdk-to-pulumi to convert an AWS CDK application to Pulumi."

--- a/migration/skills/pulumi-cdk-to-pulumi/agents/openai.yaml
+++ b/migration/skills/pulumi-cdk-to-pulumi/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AWS CDK to Pulumi Migration"
+  short_description: "Convert an AWS CDK application to Pulumi."
+  default_prompt: "Use $pulumi-cdk-to-pulumi to convert an AWS CDK application to Pulumi."

--- a/migration/skills/pulumi-terraform-to-pulumi/agents/openai.yaml
+++ b/migration/skills/pulumi-terraform-to-pulumi/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Terraform to Pulumi Migration"
+  short_description: "Migrate Terraform projects to Pulumi."
+  default_prompt: "Use $pulumi-terraform-to-pulumi to migrate Terraform infrastructure to Pulumi."

--- a/migration/skills/pulumi-terraform-to-pulumi/agents/openai.yaml
+++ b/migration/skills/pulumi-terraform-to-pulumi/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Terraform to Pulumi Migration"
-  short_description: "Migrate Terraform projects to Pulumi."
+  short_description: "Migrate Terraform projects to Pulumi"
   default_prompt: "Use $pulumi-terraform-to-pulumi to migrate Terraform infrastructure to Pulumi."


### PR DESCRIPTION
## Summary
- Add `agents/openai.yaml` for all 8 skills under `authoring/skills/*` and `migration/skills/*`.
- Use a minimal interface schema in each file: `display_name`, `short_description`, `default_prompt`.
- Standardize formatting across all files (quoted string values, consistent style).
- Ensure every `default_prompt` explicitly references its matching `$skill-name`.

## Files Added/Updated
- `authoring/skills/pulumi-automation-api/agents/openai.yaml`
- `authoring/skills/pulumi-best-practices/agents/openai.yaml`
- `authoring/skills/pulumi-component/agents/openai.yaml`
- `authoring/skills/pulumi-esc/agents/openai.yaml`
- `migration/skills/cloudformation-to-pulumi/agents/openai.yaml`
- `migration/skills/pulumi-arm-to-pulumi/agents/openai.yaml`
- `migration/skills/pulumi-cdk-to-pulumi/agents/openai.yaml`
- `migration/skills/pulumi-terraform-to-pulumi/agents/openai.yaml`

## Notes
- No `SKILL.md` behavior/content changes.
- No policy/icon/brand fields added; interface intentionally minimal.