### PR TITLE
feat: add upgrade-provider and upstream-patches skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ Skills for writing quality Pulumi programs, components, automation, and secrets 
 - **pulumi-component**: Guide for authoring ComponentResource classes
 - **pulumi-automation-api**: Best practices for using Pulumi Automation API
 - **pulumi-esc**: Guidance for working with Pulumi ESC (Environments, Secrets, and Configuration)
-
+- **pulumi-upgrade-provider**: Automate Pulumi provider repo upgrades with the upgrade-provider tool
+- **upstream-patches**: Create, amend, remove, and rebase patches for Terraform provider submodules
 ## Installation
 
 ### Claude Code Plugin System

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Write quality Pulumi programs, components, automation, and secrets management:
 | [pulumi-component](authoring/skills/pulumi-component) | Guide for authoring ComponentResource classes |
 | [pulumi-automation-api](authoring/skills/pulumi-automation-api) | Best practices for using Pulumi Automation API |
 | [pulumi-esc](authoring/skills/pulumi-esc) | Guidance for working with Pulumi ESC (Environments, Secrets, and Configuration) |
-
+| [pulumi-upgrade-provider](authoring/skills/pulumi-upgrade-provider) | Automate Pulumi provider repo upgrades |
+| [upstream-patches](authoring/skills/upstream-patches) | Manage upstream Terraform patch stacks in provider repos |
 ## Installation
 
 ### Claude Code Plugin System

--- a/authoring/.claude-plugin/plugin.json
+++ b/authoring/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulumi-authoring",
   "version": "1.0.0",
-  "description": "Write quality Pulumi programs, components, automation, and secrets management with ESC",
+  "description": "Write quality Pulumi programs, components, automation, secrets management with ESC, and provider upgrades",
   "author": {
     "name": "Pulumi",
     "url": "https://github.com/pulumi"
@@ -16,6 +16,8 @@
     "automation-api",
     "esc",
     "secrets",
-    "configuration"
+    "configuration",
+    "upgrade-provider",
+    "upstream-patches"
   ]
 }

--- a/authoring/skills/pulumi-upgrade-provider/SKILL.md
+++ b/authoring/skills/pulumi-upgrade-provider/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: pulumi-upgrade-provider
+description: Automate Pulumi provider repo upgrades with the `upgrade-provider` tool. Use when upgrading a pulumi provider repository to a new upstream version, running `upgrade-provider`, and addressing its common failure modes like patch conflicts or missing module mappings.
+---
+
+# Pulumi Upgrade Provider
+
+## Overview
+
+Run `upgrade-provider`, fix known failures, and rerun until success. Keep git operations read-only in the repo; the tool owns branch/commit/PR state.
+
+## Run Loop
+
+1. Create output directory:
+
+```bash
+mkdir -p .pulumi
+```
+
+2. Run from repo root:
+
+```bash
+upgrade-provider $ORG/$REPO --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
+```
+
+3. Wait for completion (can take up to 10 minutes).
+4. Check for errors by scanning `.pulumi/upgrade-provider-stdout.txt` lines starting with `error: `.
+5. If failed, fix using this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo), then rerun.
+6. If a fix requires creating/amending/removing/rebasing patches, use the `upstream-patches` skill for the patch workflow.
+7. If you fixed a conflict, report exact edits (file paths + concrete changes or preserved intent).
+8. If the upgrade changed patches, run `./scripts/upstream.sh checkout` and review applied `upstream` commits:
+   - List commit SHAs/titles from `upstream`.
+   - Summarize the intent of each commit in plain language.
+   - Call out any behavioral changes or risks.
+9. On success, proceed to Post-run Tasks.
+
+## When to Stop and Report Failure
+
+Stop iterating and report failure if any of these conditions are met:
+
+1. **Command not found (exit code 127)**: The `upgrade-provider` tool is not in PATH.
+2. **Same error 3 times**: You've attempted to fix the same error 3 times without success.
+3. **Unknown error pattern**: The error is not covered in `references/upgrade-provider-errors.md` and you cannot determine a safe fix.
+4. **Requires human judgment**: The fix needs user input, such as:
+   - Choosing between multiple valid approaches
+   - Breaking changes that affect public API
+   - Deprecation strategies
+   - Architectural decisions about module organization
+
+When stopping, report:
+1. The error(s) encountered.
+2. What fixes were attempted (with file paths and changes).
+3. Why human intervention is needed.
+4. Any partial progress.
+
+## Post-run Tasks
+
+The tool creates a PR on successful upgrade.
+
+1. MUST fetch the PR URL for the current branch using read-only commands:
+
+```console
+gh pr view --json url --jq .url || gh pr list --head "$(git branch --show-current)" --json url --jq '.[0].url'
+```
+
+2. MUST append a "Fixes applied to unblock upgrade" section to the existing PR body if any fixes were applied (do not overwrite):
+
+```console
+repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+pr_number=$(gh pr view --json number --jq .number)
+gh pr view --json body --jq .body > /tmp/pr_body.txt
+
+cat <<'EOF' >> /tmp/pr_body.txt
+
+---
+
+### Fixes applied to unblock upgrade
+
+- <list concrete unblocker edits here, with file paths and intent>
+EOF
+
+gh api -X PATCH "repos/$repo/pulls/$pr_number" --raw-field body="$(cat /tmp/pr_body.txt)"
+```
+
+Use REST (`gh api`) instead of `gh pr edit` to avoid GraphQL project-card errors. Keep existing body content; only append.
+
+## Notes
+
+- `git rebase --continue --no-edit` is not supported in older git versions. Use `git rebase --continue` and accept the existing commit message.
+- To avoid the editor prompt during `git rebase --continue`, run it with `GIT_EDITOR=true` (or `GIT_EDITOR=:`).
+
+## Guardrails
+
+- Never commit, push, or create branches manually; only run read-only git commands.
+- `./scripts/upstream.sh checkout|rebase|check_in` are allowed because the tool manages git state.
+- Do not stash changes; the tool manages git state.
+
+## References
+
+- Use this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo) for patch conflict and new module mapping fixes.

--- a/authoring/skills/pulumi-upgrade-provider/agents/openai.yaml
+++ b/authoring/skills/pulumi-upgrade-provider/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Pulumi Upgrade Provider"
+  short_description: "Upgrade providers and fix common upgrade blockers."
+  default_prompt: "Use $pulumi-upgrade-provider to run upgrade-provider for this repo, fix known failures, and summarize unblocker edits."

--- a/authoring/skills/pulumi-upgrade-provider/references/upgrade-provider-errors.md
+++ b/authoring/skills/pulumi-upgrade-provider/references/upgrade-provider-errors.md
@@ -1,0 +1,112 @@
+# Upgrade Provider Errors
+
+Use this file when the `upgrade-provider` tool fails and you need concrete fixes.
+For patch edits/removals/rebases, follow the `upstream-patches` skill workflow.
+
+## Patch conflicts during rebase
+
+The tool uses `scripts/upstream.sh` to apply patch commits in the `upstream` submodule. If a patch no longer applies cleanly, you will see rebase errors like:
+
+```
+error: could not apply 83b04967e... docs patching
+hint: Resolve all conflicts manually, mark them as resolved with
+hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
+```
+
+Fix from the `upstream` directory, following `upstream-patches` defaults (edit the owning patch commit; do not create a new patch unless asked):
+
+1. Identify conflicted files.
+2. Resolve conflicts while preserving the intent of the patch in `patches/`.
+3. Search for conflict markers and remove all of them before continuing.
+4. `git add` the resolved files.
+5. `git rebase --continue`.
+
+If `git rebase --continue` opens an editor in automation contexts, run with `GIT_EDITOR=true`.
+
+Avoid:
+
+- Hand-editing `patches/*.patch` unless intentionally doing raw patch surgery.
+- Direct edits under `upstream/` outside `checkout/check_in` workflow.
+
+After the rebase completes, rerun `upgrade-provider` from the repo root.
+
+### Patch intent guidance
+
+- Docs-related patches usually replace or remove Terraform references. Preserve those changes when resolving conflicts.
+
+## New resources missing module mapping
+
+When new upstream resources appear, token mapping can fail with errors like:
+
+```
+* "google_observability_trace_scope": could not find a module that prefixes 'observability_trace_scope' in '[...]'
+```
+
+Fix by updating `provider/resources.go` (or the repo-equivalent file):
+
+1. Determine the Terraform module name (usually the first segment after the provider prefix). In the example, use `observability`.
+2. Add a module mapping in `moduleMapping`:
+
+```go
+var moduleMapping = map[string]string{
+  "observability": "Observability",
+}
+```
+
+3. If related resources already map to a different module, map the new resource individually instead of adding a new module key. Example:
+
+```go
+DataSources: map[string]*tfbridge.DataSourceInfo{
+  "aws_vpn_gateway": {Tok: awsDataSource(ec2Mod, "getVpnGateway")},
+}
+```
+
+After updating, rerun `upgrade-provider`.
+
+## ID attribute wrong type (tfgen unresolved ID mapping)
+
+When `make tfgen` fails with an error like:
+
+```
+error: Resource linode_producer_image_share_group has a problem: "id" attribute is of type "Int", expected type "string". To map this resource consider overriding the SchemaInfo.Type field or specifying ResourceInfo.ComputeID
+error: There were 1 unresolved ID mapping errors
+```
+
+The upstream resource has an `id` attribute, but it is not a string. Fix it in `provider/resources.go` (or equivalent) by applying the override:
+
+```go
+prov.P.ResourcesMap().Range(func(key string, value shim.Resource) bool {
+  if value.Schema().Get("id").Type() != shim.TypeString {
+    r := prov.Resources[key]
+    if r.Fields == nil {
+      r.Fields = make(map[string]*tfbridge.SchemaInfo, 1)
+    }
+    r.Fields["id"] = &tfbridge.SchemaInfo{Type: "string"}
+  }
+  return true
+})
+```
+
+- If the `id` type is not coercible to string, set `ResourceInfo.ComputeID` instead.
+
+## ID attribute is input type (tfgen unresolved ID mapping)
+
+When `make tfgen` fails with an error like:
+
+```
+error: Resource cloudflare_zero_trust_access_ai_controls_mcp_server has a problem: an "id" input attribute is not allowed. To map this resource specify SchemaInfo.Name and ResourceInfo.ComputeID
+```
+
+The upstream resource exposes `id` as Optional/Required. Remap the input field to `<resource_name>_id` and delegate the ID to that new property. Convert the field name to Pulumi camelCase (for example, `cloudflare_zero_trust_access_ai_controls_mcp_server` -> `zeroTrustAccessAiControlsMcpServerId`).
+
+```go
+"cloudflare_zero_trust_access_ai_controls_mcp_server": {
+  Fields: map[string]*info.Schema{
+    "id": {
+      Name: "zeroTrustAccessAiControlsMcpServerId",
+    },
+  },
+  ComputeID: tfbridge.DelegateIDField(resource.PropertyKey("zeroTrustAccessAiControlsMcpServerId"),
+    "cloudflare", "https://github.com/pulumi/pulumi-cloudflare"),
+},
+```

--- a/authoring/skills/upstream-patches/SKILL.md
+++ b/authoring/skills/upstream-patches/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: upstream-patches
+description: Create, amend, remove, and rebase patches for Terraform provider submodules using `./scripts/upstream.sh`. Use when `upgrade-provider` or manual patch work needs owning-patch lookup, patch conflict fixes, patch/hunk removal, or upstream rebase.
+---
+
+# Upstream Patches
+
+`upstream/` is a git submodule pointing to the upstream Terraform provider. `patches/` contains patch files applied on top of it. Use `./scripts/upstream.sh` to manage patch state.
+
+## Default Behavior
+
+- If fixing a regression introduced by an existing patch, amend the owning patch commit.
+- Do not create a new patch unless the user explicitly asks.
+
+## Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `./scripts/upstream.sh init` | Initialize upstream and apply patches to working directory |
+| `./scripts/upstream.sh init -f` | Force re-initialize, discarding any changes |
+| `./scripts/upstream.sh checkout` | Create branch with patches as commits for editing |
+| `./scripts/upstream.sh rebase -i` | Interactively edit patch commits |
+| `./scripts/upstream.sh rebase -o <commit>` | Rebase patches onto a new upstream commit |
+| `./scripts/upstream.sh check_in` | Write commits back to patches and exit checkout mode |
+
+## Guardrails
+
+- Never commit directly to `upstream/` without `checkout/check_in`.
+- Direct edits under `upstream/` outside checkout are ephemeral during `upgrade-provider`; the tool resets submodule state.
+- Do not hand-edit `patches/*.patch` unless intentionally doing raw patch surgery.
+- Prefer non-interactive rewrite flow over interactive rebase for agents.
+
+## Find Owning Patch First
+
+Before editing patch content, identify the owning patch/commit.
+
+```bash
+./scripts/upstream.sh checkout
+
+# Find candidate patch files by touched file path or unique hunk text
+rg -n "path/to/file|unique_symbol" patches/*.patch
+
+# Optional: inspect candidate patch header/hunks
+sed -n '1,120p' patches/00NN-Example.patch
+
+# Map patch file to commit in upstream checkout branch
+patch=patches/00NN-Example.patch
+subject=$(sed -n 's/^Subject: \[PATCH\] //p' "$patch" | head -n1)
+cd upstream
+git log --oneline pulumi/patch-checkout --grep "$subject"
+
+# If needed, disambiguate by touched path
+git log --oneline pulumi/patch-checkout -- path/to/file
+cd ..
+```
+
+Set `target_sha` to the owning commit and edit that commit, not `HEAD`.
+
+## Amend Existing Patch (Preferred, Non-Interactive)
+
+```bash
+./scripts/upstream.sh checkout
+cd upstream
+
+target_sha=<owning-commit-sha>
+base_sha=$(git rev-parse "${target_sha}^")
+tmp_branch="rewrite-${target_sha:0:8}"
+
+# Rebuild history from parent of target commit
+git checkout -b "$tmp_branch" "$base_sha"
+git cherry-pick "$target_sha"
+
+# Apply fix and amend target commit
+# ...edit files...
+git add <files>
+git commit --amend --no-edit
+
+# Replay remaining commits
+git cherry-pick "${target_sha}..pulumi/patch-checkout"
+
+# If cherry-pick conflicts occur:
+#   resolve files
+#   git add <resolved files>
+#   git cherry-pick --continue
+
+# Move checkout branch to rewritten history
+git branch -f pulumi/patch-checkout HEAD
+git checkout pulumi/patch-checkout
+git branch -D "$tmp_branch"
+cd ..
+```
+
+Interactive fallback:
+
+```bash
+./scripts/upstream.sh checkout
+./scripts/upstream.sh rebase -i
+# mark target commit as edit, amend, then continue
+```
+
+## Remove Entire Patch
+
+Use when a patch should be deleted completely.
+
+```bash
+rm patches/00NN-Description.patch
+./scripts/upstream.sh checkout
+./scripts/upstream.sh check_in
+```
+
+## Remove Part of a Patch
+
+Use when only selected hunks/files should be removed from an existing patch.
+
+1. Find owning patch/commit (`target_sha`) and use the amend workflow above.
+2. Revert only unwanted changes from the target commit, then amend.
+
+Example during amend step:
+
+```bash
+cd upstream
+# Restore specific docs-only files from parent of amended commit
+git checkout HEAD^ -- path/to/docs-only-file path/to/another-doc-file
+git add path/to/docs-only-file path/to/another-doc-file
+git commit --amend --no-edit
+cd ..
+```
+
+## Create New Patch (Only If Requested)
+
+```bash
+./scripts/upstream.sh checkout
+cd upstream
+# ...make changes...
+git add <files>
+git commit -m "Describe new patch"
+cd ..
+./scripts/upstream.sh check_in
+```
+
+## Rebasing Patches to a New Upstream Version
+
+```bash
+./scripts/upstream.sh checkout
+
+# Rebase onto the new upstream commit
+./scripts/upstream.sh rebase -o <new_commit_sha>
+# Resolve any conflicts that arise
+
+# Write updated patch files
+./scripts/upstream.sh check_in
+```
+
+## Verification Checklist
+
+Before `check_in`:
+
+- Confirm expected patch count change (`0` by default; `-1` for full patch removal).
+- Confirm whether target patch should remain present (default yes) or be removed (explicit deletion case).
+- Confirm you are editing the owning commit, not adding a new commit by accident.
+
+After `check_in`:
+
+- Verify patch count matches expectation.
+- Verify target patch number/purpose is still present when expected.
+- Verify no unexpected new `00NN-*.patch` was introduced.
+
+If checkout mode is stuck, use `./scripts/upstream.sh init -f` to reset.

--- a/authoring/skills/upstream-patches/agents/openai.yaml
+++ b/authoring/skills/upstream-patches/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Upstream Patches"
+  short_description: "Manage upstream Terraform patch stacks in provider repos."
+  default_prompt: "Use $upstream-patches to find owning patches, amend or remove patch content safely, and verify patch set integrity."


### PR DESCRIPTION
## Summary

- Add `pulumi-upgrade-provider` skill to automate Pulumi provider repo upgrades with the `upgrade-provider` tool
- Add `upstream-patches` skill to manage upstream Terraform patch stacks in provider repos
- Both skills are copied from `pulumi-skills-internal` and placed in the `authoring` plugin group
- Update `plugin.json` keywords, `README.md`, and `AGENTS.md` to register the new skills

## Test plan

- [ ] Verify skill files are correctly structured under `authoring/skills/`
- [ ] Verify `plugin.json` has valid JSON with new keywords
- [ ] Verify README.md table renders correctly with new skill entries
- [ ] Verify AGENTS.md lists both new skills in the authoring section