### PR TITLE
Import and generalize provider-upgrade skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Skills for writing quality Pulumi programs, components, automation, and secrets 
 - **pulumi-component**: Guide for authoring ComponentResource classes
 - **pulumi-automation-api**: Best practices for using Pulumi Automation API
 - **pulumi-esc**: Guidance for working with Pulumi ESC (Environments, Secrets, and Configuration)
+- **provider-upgrade**: Safe workflows for upgrading Pulumi providers without unintended infrastructure changes
 
 ## Installation
 
@@ -46,7 +47,7 @@ Or install individual plugin groups:
 
 ```bash
 npx skills add pulumi/agent-skills/migration --skill '*'     # 4 migration skills
-npx skills add pulumi/agent-skills/authoring --skill '*'     # 4 authoring skills
+npx skills add pulumi/agent-skills/authoring --skill '*'     # 5 authoring skills
 ```
 
 This works with Claude Code, Cursor, Copilot, Codex, and other agent tools.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Write quality Pulumi programs, components, automation, and secrets management:
 | [pulumi-component](authoring/skills/pulumi-component) | Guide for authoring ComponentResource classes |
 | [pulumi-automation-api](authoring/skills/pulumi-automation-api) | Best practices for using Pulumi Automation API |
 | [pulumi-esc](authoring/skills/pulumi-esc) | Guidance for working with Pulumi ESC (Environments, Secrets, and Configuration) |
+| [provider-upgrade](authoring/skills/provider-upgrade) | Safe workflows for upgrading Pulumi providers without unintended infrastructure changes |
 
 ## Installation
 
@@ -68,7 +69,7 @@ Or install individual plugin groups:
 
 ```bash
 npx skills add pulumi/agent-skills/migration --skill '*'     # 4 migration skills
-npx skills add pulumi/agent-skills/authoring --skill '*'     # 4 authoring skills
+npx skills add pulumi/agent-skills/authoring --skill '*'     # 5 authoring skills
 ```
 
 This works with Claude Code, Cursor, Copilot, Codex, and other agent tools.
@@ -111,6 +112,16 @@ Help me create a reusable Pulumi component for a web service
 ```
 
 The assistant will use the `pulumi-component` skill to guide you through component authoring best practices.
+
+### Upgrading Providers
+
+Ask your AI assistant:
+
+```text
+Help me upgrade the Pulumi AWS provider safely without changing real infrastructure
+```
+
+The assistant will use the `provider-upgrade` skill to guide you through a low-risk upgrade workflow.
 
 ## Contributing
 

--- a/authoring/.claude-plugin/plugin.json
+++ b/authoring/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulumi-authoring",
   "version": "1.0.0",
-  "description": "Write quality Pulumi programs, components, automation, and secrets management with ESC",
+  "description": "Write quality Pulumi programs, components, provider upgrades, automation, and secrets management with ESC",
   "author": {
     "name": "Pulumi",
     "url": "https://github.com/pulumi"
@@ -14,6 +14,7 @@
     "best-practices",
     "component",
     "automation-api",
+    "provider-upgrade",
     "esc",
     "secrets",
     "configuration"

--- a/authoring/skills/provider-upgrade/SKILL.md
+++ b/authoring/skills/provider-upgrade/SKILL.md
@@ -5,7 +5,8 @@ description: >
   update a provider, update provider dependencies, check for breaking changes, or bump provider
   versions in their code. This applies to all providers (aws, azure-native, gcp, kubernetes,
   aws-native, cloudflare, datadog, etc.) - not just Tier 1 providers. Do NOT use for just
-  querying which stacks use what versions (that's package-usage) or for general infrastructure tasks.
+  querying which stacks use what versions. Use skill `package-usage` for version audits and
+  affected-stack discovery. Do NOT use for general infrastructure tasks.
 ---
 
 # Upgrading Pulumi Providers
@@ -198,22 +199,19 @@ steps) before proceeding.
 
 ### Required environment variables
 
-A preview without these shows false diffs (phantom tag removals, region additions) that
-aren't real. Don't interpret a preview that was run without them.
+When your execution environment lets you set environment variables for preview, use
+these. A preview without them can show false diffs (phantom tag removals, region
+additions) that aren't real. Don't interpret a preview that was run without them.
 
-```
-pulumi_preview(
-    environment_variables={
-        "PULUMI_OPTION_REFRESH": "true",
-        "PULUMI_RUN_PROGRAM": "true",
-    }
-)
+```shell
+PULUMI_OPTION_REFRESH=true
+PULUMI_RUN_PROGRAM=true
 ```
 
-- `PULUMI_OPTION_REFRESH` triggers a refresh of actual cloud state before diffing.
-- `PULUMI_RUN_PROGRAM` runs the Pulumi program during refresh. This is an executor-level
-  variable - do not use `PULUMI_OPTION_RUN_PROGRAM` (that passes `--run-program` as a
-  CLI flag, which is wrong).
+- `PULUMI_OPTION_REFRESH` refreshes actual cloud state before diffing.
+- `PULUMI_RUN_PROGRAM` runs the Pulumi program during refresh.
+- Do not use `PULUMI_OPTION_RUN_PROGRAM`. That attempts to pass `--run-program` as a
+  CLI flag, which is not the same thing.
 
 ### Don't chase deprecations
 
@@ -247,10 +245,12 @@ PR -> review -> merge -> deploy via CI/CD.
 
 ### 1. Get version information
 
-Use `call_pulumi_cloud_api`:
-`GET /api/registry/packages?name={package_name}&orgLogin={orgName}`
+Determine the target version from the user's request, the Pulumi Registry, package
+manager metadata, or the repository's existing dependency constraints.
 
-Default to latest if the user hasn't specified a target version.
+Default to the latest stable version if the user hasn't specified a target version.
+If the user asks which stacks or projects are affected, use skill `package-usage` or
+the best available package inventory tooling before making changes.
 
 ### 2. Update the dependency
 
@@ -266,9 +266,10 @@ go.sum, etc.) - use these exact versions for schema-tools comparisons.
 
 ### 3. Run preview
 
-Run `pulumi_preview` with the required environment variables immediately after updating
-the dependency. Do not research breaking changes first - many upgrades just work,
-especially minor versions.
+Run `pulumi preview` immediately after updating the dependency, passing the required
+environment variables through whatever CLI, wrapper, or agent tooling is available.
+Do not research breaking changes first - many upgrades just work, especially minor
+versions.
 
 If the preview is clean (only the provider version bump), create a PR.
 
@@ -329,5 +330,5 @@ report and ask the user how they'd like to proceed before creating a PR.
 ## References
 
 - `references/diagnostic-toolbox.md` - upgrade guides, schema-tools (install, run,
-  interpret output), resource_search, SDK types, GitHub issues. Read when investigating
-  Category B diffs.
+  interpret output), stack state inspection, SDK types, GitHub issues. Read when
+  investigating Category B diffs.

--- a/authoring/skills/provider-upgrade/SKILL.md
+++ b/authoring/skills/provider-upgrade/SKILL.md
@@ -256,7 +256,7 @@ the best available package inventory tooling before making changes.
 - **Go**: `go get github.com/pulumi/pulumi-{provider}/sdk/v{major}@latest`, update all import paths (e.g., `v6` -> `v7`), run `go mod tidy`
 - **.NET**: `dotnet add package Pulumi.{Provider} --version {version}`
 - **Java**: Update `pom.xml` or `build.gradle` dependency version
-- **YAML**: Update provider version in resource options or provider configuration
+- **YAML**: Update provider version in resource options or provider configuration. See https://www.pulumi.com/docs/iac/languages-sdks/yaml/yaml-language-reference/#providers-and-provider-versions for examples.
 
 After installing, check the actual installed version from the lockfile (package-lock.json,
 go.sum, etc.) - use these exact versions for schema-tools comparisons.
@@ -311,7 +311,7 @@ upstream GitHub issue). "I believe this is expected" is not a source.
 ### Manual Steps Required (if any)
 1. `pulumi state delete '<urn>'` - remove old type binding
 2. `pulumi import <type> <name> <id>` - adopt under new type
-3. `pulumi preview` - verify clean
+3. `pulumi preview --refresh --run-program` - verify clean
 
 ### Deprecation Warnings (no action taken)
 - List deprecated-but-working code left intentionally

--- a/authoring/skills/provider-upgrade/SKILL.md
+++ b/authoring/skills/provider-upgrade/SKILL.md
@@ -56,7 +56,7 @@ flowchart TD
 ```
 
 1. **Bump** the provider dependency
-2. **Preview** with required environment variables
+2. **Preview** with required CLI flags
 3. **Diff Checkpoint** - categorize every non-`same` resource (see next section)
 4. **Fix Category A** - code changes that didn't produce `same`
 5. **Investigate Category B** - diffs on resources you didn't change
@@ -197,21 +197,18 @@ steps) before proceeding.
 
 ## Hard Rules
 
-### Required environment variables
+### Required CLI flags
 
-When your execution environment lets you set environment variables for preview, use
-these. A preview without them can show false diffs (phantom tag removals, region
-additions) that aren't real. Don't interpret a preview that was run without them.
+Use these flags when running preview. A preview without them can show false diffs
+(phantom tag removals, region additions) that aren't real. Don't interpret a preview
+that was run without them.
 
 ```shell
-PULUMI_OPTION_REFRESH=true
-PULUMI_RUN_PROGRAM=true
+pulumi preview --refresh --run-program
 ```
 
-- `PULUMI_OPTION_REFRESH` refreshes actual cloud state before diffing.
-- `PULUMI_RUN_PROGRAM` runs the Pulumi program during refresh.
-- Do not use `PULUMI_OPTION_RUN_PROGRAM`. That attempts to pass `--run-program` as a
-  CLI flag, which is not the same thing.
+- `--refresh` refreshes actual cloud state before diffing.
+- `--run-program` runs the Pulumi program during refresh.
 
 ### Don't chase deprecations
 
@@ -266,8 +263,7 @@ go.sum, etc.) - use these exact versions for schema-tools comparisons.
 
 ### 3. Run preview
 
-Run `pulumi preview` immediately after updating the dependency, passing the required
-environment variables through whatever CLI, wrapper, or agent tooling is available.
+Run `pulumi preview --refresh --run-program` immediately after updating the dependency.
 Do not research breaking changes first - many upgrades just work, especially minor
 versions.
 

--- a/authoring/skills/provider-upgrade/SKILL.md
+++ b/authoring/skills/provider-upgrade/SKILL.md
@@ -1,120 +1,333 @@
 ---
 name: provider-upgrade
-description: Upgrade Pulumi providers to newer versions. Use when users need to upgrade providers (pulumi-aws, pulumi-azure-native, pulumi-gcp, pulumi-kubernetes), update dependencies, check for breaking changes, or update provider versions across stacks.
+description: >
+  Upgrade any Pulumi provider to a newer version. Use when users explicitly want to upgrade or
+  update a provider, update provider dependencies, check for breaking changes, or bump provider
+  versions in their code. This applies to all providers (aws, azure-native, gcp, kubernetes,
+  aws-native, cloudflare, datadog, etc.) - not just Tier 1 providers. Do NOT use for just
+  querying which stacks use what versions (that's package-usage) or for general infrastructure tasks.
 ---
 
 # Upgrading Pulumi Providers
 
-## Pre-Upgrade Assessment
+## The Principle
 
-1. **Get the latest version** via `call_pulumi_cloud_api`:
-   `GET /api/registry/packages?name={package_name}&orgLogin={orgName}`
-   The response `packages[].version` field has the latest version.
+A provider upgrade is a translation, not a change request.
 
-2. **Find affected stacks** via `call_pulumi_cloud_api`:
-   `GET /api/orgs/{orgName}/packages/usage?packageName={package_name}`
-   Returns `stacks[]` with `{stackName, projectName, version, lastUpdate}`.
+The user's infrastructure intent hasn't changed - they still want the same bucket, the
+same function, the same cluster. What changed is how the provider's API expresses that
+intent. Your job is to translate their existing code into the new API so that Pulumi sees
+no difference between what the code says and what already exists.
 
-3. **Determine upgrade type**:
-   - **Major version** (e.g., v6 to v7): Likely has breaking changes, requires migration guide review
-   - **Minor/patch version** (e.g., v7.1 to v7.2): Usually backwards-compatible, lower risk
+There are four layers to keep in mind:
 
-## Finding Breaking Change Documentation
+1. **User intent** - what the user wants in the cloud (unchanged during an upgrade)
+2. **Code** - how the program expresses that intent using the provider API (may need updating)
+3. **Pulumi state** - Pulumi's stored representation of what exists (may need reconciliation)
+4. **Real cloud** - the actual infrastructure (should not change during an upgrade)
 
-For major version upgrades, search for a migration guide using `web_search`:
+During an upgrade, layers 2 and 3 may need to change so that they continue to correctly
+represent the unchanged layers 1 and 4.
 
-```
-site:pulumi.com {provider} migration guide v{major}
-```
+A correct translation produces zero diff. The Pulumi engine doesn't have a concept of
+"upgrade" - it just compares goal state (your code) against actual state (the state file)
+and reconciles. If the translation is correct, those two states match and nothing happens.
+If you see a diff, either your translation is wrong, or something beyond a code change is
+needed (import, alias, manual step). In all cases, the diff is a problem to solve, not a
+consequence to accept.
 
-Example: `site:pulumi.com pulumi-aws migration guide v7`
+## The Core Loop
 
-If no migration guide is found, search more broadly:
-
-```
-site:pulumi.com {provider} v{major} upgrade breaking changes
-```
-
-Migration guides exist for some major provider versions but not all. If no guide is found, note this in the upgrade summary and rely on preview results to identify breaking changes.
-
-## Present Upgrade Summary
-
-Present a summary to the user:
-
-```
-## Upgrade Summary: {provider} {current_version} -> {target_version}
-
-### Affected Stacks
-
-| Project | Stack | Current Version | Target Version |
-|---------|-------|-----------------|----------------|
-| ... | ... | ... | ... |
-
-### Breaking Changes
-
-{Summary from migration guide, or "No migration guide found. Preview results will be used to identify any issues."}
-
-### Actions Required
-
-For each stack:
-- {project}/{stack}: {anticipated actions, e.g., "Update import paths", "Add alias for renamed resource", "No code changes expected"}
+```mermaid
+flowchart TD
+    A[Bump version] --> B[Run preview with env vars]
+    B --> C{Clean?}
+    C -->|Yes| D[Create PR]
+    C -->|No| E[Diff Checkpoint: categorize every diff]
+    E --> F{Any Category A?}
+    F -->|Yes| G[Fix wrong translations]
+    G --> B
+    F -->|No| H{Any Category B?}
+    H -->|Yes| I[Investigate with toolbox]
+    I --> J[Fix or document]
+    J --> B
+    H -->|No| D
 ```
 
-You must ask for user confirmation before proceeding with the upgrade.
+1. **Bump** the provider dependency
+2. **Preview** with required environment variables
+3. **Diff Checkpoint** - categorize every non-`same` resource (see next section)
+4. **Fix Category A** - code changes that didn't produce `same`
+5. **Investigate Category B** - diffs on resources you didn't change
+6. **Repeat** until clean or remaining diffs are fully investigated
+7. **Create PR** with upgrade summary
 
-## Upgrade Workflow
+---
 
-**Important**: Process stacks one at a time. Complete the entire workflow for one stack (including opening a PR) before moving to the next. Work through all stacks in a given environment tier (e.g., all dev stacks) before moving to the next tier (staging, then production).
+## The Diff Checkpoint
 
-**Exception**: If stacks have dependencies on each other (e.g., a shared infrastructure stack that other stacks reference), upgrade and test them together in a single PR.
+This is the most important section. Run this after EVERY preview.
 
-For each stack:
+For each non-`same` resource, answer one question:
+**"Did any of my code changes affect this resource - directly or indirectly?"**
 
-### 1. Update Dependencies
+"Directly" means you edited the resource block itself. "Indirectly" means you changed
+something that feeds into this resource - a shared variable, an output from another
+resource, a helper function, a default value, or a resource that this one depends on.
+If your changes could have altered what Pulumi computes for this resource, it's Category A.
 
-Update the provider dependency using the appropriate package manager:
+Then follow the category that applies.
 
-- **TypeScript/JavaScript**: `npm install @pulumi/{provider}@^{version}` or `yarn add @pulumi/{provider}@^{version}`
-- **Python**: Update `pyproject.toml` or `requirements.txt` with `pulumi_{provider} >= {version}` (note: underscore, not hyphen), then `pip install -e .` or equivalent
-- **Go**: `go get github.com/pulumi/pulumi-{provider}/sdk/v{major}@latest` — also update all import paths (e.g., `v6` to `v7`) and run `go mod tidy`
-- **.NET**: `dotnet add package Pulumi.{Provider} --version {version}`
-- **Java**: Update `pom.xml` or `build.gradle` dependency version
-- **YAML**: Provider versions are set as resource options on the default provider or as explicit provider configuration. See https://www.pulumi.com/docs/iac/languages-sdks/yaml/yaml-language-reference/#providers-and-provider-versions for examples.
+### Category A: I changed code for this resource
 
-### 2. Run Preview
+Your code change was supposed to translate the same intent into the new API. If the
+resource shows `same`, your translation is correct. If it shows anything else, your
+translation is wrong. Not "the diff is expected because I changed the code" - if the
+change were semantically equivalent, there would be no diff.
 
-Use `pulumi_preview` to see what changes would be made. Review the `update_summary` for:
-- **Resource replacements**: May indicate breaking changes in resource schemas
-- **Property changes**: Check if defaults changed or properties were renamed
-- **Import errors**: Type or property name changes
+**I modified an existing resource and it shows `update`:**
 
-Present any diagnostics (warnings or errors) to the user.
+Your rename, restructure, or value adjustment changed the meaning, not just the syntax.
+The resource would show `same` if the old and new code compiled to the same goal state.
+The `update` means they don't.
 
-When presenting preview results, explain whether changes are expected based on the breaking changes research.
+Ask yourself: *"If this rename were truly equivalent, the resource would show `same`.
+It doesn't. What is semantically different between my old code and my new code?"*
 
-If the preview contains diagnostic warnings or errors, stop and ask the user if they want to address them before proceeding. Do not ask to create a PR without first asking the user if they would like to address any warnings or errors.
+Common causes: the new property name maps to a different underlying field; the value
+shape changed and your conversion lost or added information; a default value changed
+in the new version and you need to explicitly set the old value; additional properties
+now appear in the diff because the new provider version tracks fields it didn't before
+(these need to be set explicitly to match the current state).
 
-### 3. Address Breaking Changes
+If the update includes properties you didn't change - new fields appearing, type
+normalizations (string->number), additional defaults - that's the provider changing what
+it tracks. But if the diff is there, `pulumi up` WILL send those values to the cloud API.
+Don't assume they're no-ops. Investigate each changed property.
 
-Common breaking change patterns:
+**I added a new resource block and it shows `create`:**
 
-**Resource renames** — Use aliases to preserve state:
+During an upgrade, a new resource block almost always represents infrastructure that
+already exists in the cloud. The old provider managed it implicitly (as part of another
+resource); the new provider needs an explicit resource. But the cloud object is already
+there. Pulumi wants to create NEW infrastructure - that's not what you want.
+
+The fix is `import`, not `create`. Tell Pulumi to adopt the existing cloud resource.
+
+Ask yourself: *"What cloud object does this new resource represent? Does it already
+exist? How was it managed before the upgrade?"*
+
 ```typescript
-const bucket = new aws.s3.Bucket("my-bucket", { /* ... */ }, {
-    aliases: [{ type: "aws:s3:BucketV2" }]  // old type name
+// Wrong - creates duplicate infrastructure
+const stage = new aws.apigateway.Stage("prodStage", { ... });
+
+// Right - adopts the existing resource
+const stage = new aws.apigateway.Stage("prodStage", { ... }, {
+    import: "<rest-api-id>/prod",  // import ID format varies by resource type
 });
 ```
 
-**Property renames** — Update code to use new property names. Check migration guide if available.
+**I removed a resource block and it shows `delete`:**
 
-**Removed properties** — Some properties may be removed or moved to separate resources. Check migration guide if available.
+A `delete` in the preview means `pulumi up` will call the provider's Delete API to
+destroy or unconfigure this cloud resource. This is real destruction - not just state
+cleanup. The cloud infrastructure still exists and is almost certainly still needed.
 
-### 4. Iterate Until Clean
+This is different from `pulumi state delete`, which removes the resource from Pulumi's
+tracking WITHOUT calling the provider's API. When a resource type is removed in a new
+provider version, the correct approach is:
+1. `pulumi state delete '<urn>'` - manual step, removes from tracking only
+2. Add replacement resources (if any) with imports - adopts the cloud state under new types
+3. Verify with preview
 
-Repeat `pulumi_preview` and fix issues until the preview shows no unexpected changes and no errors. Provider version metadata diffs are acceptable.
+Do NOT leave a `delete` in the preview and proceed to PR creation. A delete that runs
+via `pulumi up` will destroy real infrastructure. If the resource must be removed from
+state, document it as a manual step for the user.
 
-### 5. Open Pull Request
+Ask yourself: *"What cloud infrastructure does this resource manage? If `pulumi up` runs
+this delete, what gets destroyed or unconfigured?"*
 
-Once clean, create a pull request for this stack's changes. Then proceed to the next stack.
+### Category B: I didn't change code for this resource
 
-**Do not run `pulumi_up`**. Deployments happen through the PR/merge process, not directly.
+This diff was not caused by your code changes. It comes from the provider version change
+itself - a different default, a changed state representation, or a behavioral difference.
+Read `references/diagnostic-toolbox.md` and investigate.
+
+These diffs might be:
+- **Fixable with code** - set an explicit value for a changed default, add an alias
+- **A documented no-op** - the upgrade guide says it resolves on `pulumi up` without
+  affecting real infrastructure. This classification REQUIRES a citation from the upgrade
+  guide or provider documentation. Your own judgment that "this looks like a no-op" is
+  not sufficient - the user is trusting you to distinguish real infrastructure changes
+  from artifacts, and getting it wrong means unexpected changes to their cloud.
+- **Requiring manual steps** - state removal + reimport, documented for the user
+- **Unknown** - present what you've found to the user and ask for guidance
+
+### Category C: Provider version bump
+
+An `update` on `pulumi:providers:{name}` showing only a version change is the one
+expected diff. Verify no other properties changed on the provider resource.
+
+### After categorizing
+
+**Completeness check:** Every resource in the preview that shows any non-`same` state
+must appear in your checkpoint - including resources with `[diff: ...]` annotations,
+even if they don't have an explicit create/update/delete marker. If you didn't list it,
+your checkpoint is incomplete. Go back and categorize the missing resources.
+
+**Evidence requirement for accepted diffs:** If you want to accept any diff as "OK"
+(not fix it), you need evidence - whether it's Category A or Category B. "I believe the
+API treats these equivalently" or "this looks like state reconciliation" is not evidence.
+Acceptable evidence: the upgrade guide documents it, a GitHub issue confirms it, or the
+provider documentation explains the behavior. If you can't find evidence, either fix the
+diff or flag it to the user.
+
+**Ordering:** Fix all Category A issues before investigating Category B. Your code
+corrections will change the preview output, so investigating Category B diffs first wastes
+effort. Fix your own mistakes first, re-preview, then look at what remains.
+
+**No `delete` or `replace` in the final preview.** If a delete or replace remains when
+you're ready to create a PR, stop. A delete means `pulumi up` will destroy cloud
+infrastructure. A replace means it will destroy and recreate. These are never acceptable
+as "remaining diffs" - they must be resolved (via code fix, alias, or documented manual
+steps) before proceeding.
+
+---
+
+## Hard Rules
+
+### Required environment variables
+
+A preview without these shows false diffs (phantom tag removals, region additions) that
+aren't real. Don't interpret a preview that was run without them.
+
+```
+pulumi_preview(
+    environment_variables={
+        "PULUMI_OPTION_REFRESH": "true",
+        "PULUMI_RUN_PROGRAM": "true",
+    }
+)
+```
+
+- `PULUMI_OPTION_REFRESH` triggers a refresh of actual cloud state before diffing.
+- `PULUMI_RUN_PROGRAM` runs the Pulumi program during refresh. This is an executor-level
+  variable - do not use `PULUMI_OPTION_RUN_PROGRAM` (that passes `--run-program` as a
+  CLI flag, which is wrong).
+
+### Don't chase deprecations
+
+If something is deprecated but still works, leave it alone. Migrating to the replacement
+introduces risk for no benefit. A deprecation warning is acceptable - a diff is not.
+
+```typescript
+// BAD: migrating deprecated-but-working properties introduces risk
+new aws.s3.Bucket('bucket');
+new aws.s3.BucketLogging('bucketLogging', {...});  // unnecessary migration
+
+// GOOD: fix only the actual error, leave working code alone
+new aws.s3.Bucket('bucket', {
+  logging: {...},  // "loggings" renamed to "logging" - real breaking change
+  website: {...},  // deprecated but works - don't touch
+});
+```
+
+### Be minimally invasive
+
+Every line changed could introduce a regression. Prefer the smallest change that works.
+
+### Do not run pulumi up
+
+Provider upgrades modify source code and need code review before deployment.
+PR -> review -> merge -> deploy via CI/CD.
+
+---
+
+## Getting Started
+
+### 1. Get version information
+
+Use `call_pulumi_cloud_api`:
+`GET /api/registry/packages?name={package_name}&orgLogin={orgName}`
+
+Default to latest if the user hasn't specified a target version.
+
+### 2. Update the dependency
+
+- **TypeScript/JavaScript**: `npm install @pulumi/{provider}@^{version}` or `yarn add @pulumi/{provider}@^{version}`
+- **Python**: Update `pyproject.toml` or `requirements.txt` with `pulumi_{provider}>={version}` (underscore, not hyphen), then install
+- **Go**: `go get github.com/pulumi/pulumi-{provider}/sdk/v{major}@latest`, update all import paths (e.g., `v6` -> `v7`), run `go mod tidy`
+- **.NET**: `dotnet add package Pulumi.{Provider} --version {version}`
+- **Java**: Update `pom.xml` or `build.gradle` dependency version
+- **YAML**: Update provider version in resource options or provider configuration
+
+After installing, check the actual installed version from the lockfile (package-lock.json,
+go.sum, etc.) - use these exact versions for schema-tools comparisons.
+
+### 3. Run preview
+
+Run `pulumi_preview` with the required environment variables immediately after updating
+the dependency. Do not research breaking changes first - many upgrades just work,
+especially minor versions.
+
+If the preview is clean (only the provider version bump), create a PR.
+
+---
+
+## Preview Progress
+
+Preview can fail on the first error and hide others. Fixing one error often reveals new
+errors. This is normal progress, not a sign that fixes are making things worse.
+
+- **New or different errors** -> progress, continue
+- **Error set shrank** -> progress, continue
+- **Same error persists** -> your fix didn't work, try a different approach
+- **No errors but diffs** -> run the diff checkpoint
+
+---
+
+## Upgrade Summary
+
+Once the preview is clean (or as clean as possible), present the summary:
+
+```
+## Upgrade Summary: {provider} v{current} -> v{target}
+
+### Code Changes
+| File | Change | Why it preserves intent |
+|------|--------|------------------------|
+| package.json | Version bump | - |
+| index.ts:15 | loggings -> logging | Property renamed, same underlying field |
+
+### Preview Result
+All resources show `same` except provider version bump.
+{Or: N resources show diffs - see below}
+
+### Remaining Diffs (if any)
+| Resource | Operation | What happens on `pulumi up` | Risk | Source |
+|----------|-----------|---------------------------|------|--------|
+| aws:s3:Bucket (myBucket) | update (-tags) | No-op, state reconciles | None | AWS v7 guide section 3.2 |
+
+Every remaining diff MUST cite an authoritative source (upgrade guide, provider docs,
+upstream GitHub issue). "I believe this is expected" is not a source.
+
+### Manual Steps Required (if any)
+1. `pulumi state delete '<urn>'` - remove old type binding
+2. `pulumi import <type> <name> <id>` - adopt under new type
+3. `pulumi preview` - verify clean
+
+### Deprecation Warnings (no action taken)
+- List deprecated-but-working code left intentionally
+```
+
+If the preview is clean (or all remaining diffs are documented no-ops with cited sources),
+create a pull request. If unresolved diffs remain, present the summary as an exception
+report and ask the user how they'd like to proceed before creating a PR.
+
+---
+
+## References
+
+- `references/diagnostic-toolbox.md` - upgrade guides, schema-tools (install, run,
+  interpret output), resource_search, SDK types, GitHub issues. Read when investigating
+  Category B diffs.

--- a/authoring/skills/provider-upgrade/references/diagnostic-toolbox.md
+++ b/authoring/skills/provider-upgrade/references/diagnostic-toolbox.md
@@ -1,0 +1,121 @@
+# Diagnostic Toolbox
+
+Use these tools to investigate diffs - especially Category B diffs (resources you didn't
+change code for). Reach for whichever tool fits the situation.
+
+For major version upgrades, check the upgrade guide early - even alongside the first
+preview. Upgrade guides contain sequencing requirements and edge cases that no other
+tool can surface.
+
+## Upgrade Guide (Pulumi or Terraform)
+
+The most valuable resource for major version bumps. Contains migration patterns,
+sequencing requirements, and documents which diffs are known preview artifacts.
+
+The upgrade guide is the ONLY authoritative source for classifying a diff as a "known
+no-op" - a diff that shows in preview but resolves on `pulumi up` without affecting
+real infrastructure.
+
+**Pulumi upgrade guide:**
+`web_search` for `site:pulumi.com {provider} migration guide v{major}`
+
+**Terraform upgrade guide** (for Terraform-based providers):
+Check `https://registry.terraform.io/providers/{org}/{tf-provider}/latest/docs/guides/version-{major}-upgrade`
+or `web_search` for `site:registry.terraform.io {tf-provider} version {major} upgrade`
+
+**When to use:** For any major version upgrade. Check it early.
+
+## schema-tools - structured diff between versions
+
+A structured diff of every schema change between provider versions. For large providers,
+the diff can contain thousands of changes - always cross-reference with `resource_search`
+to filter to resources actually in the stack.
+
+**Install** (if not available):
+
+```shell
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case "$ARCH" in x86_64) ARCH="amd64" ;; aarch64|arm64) ARCH="arm64" ;; esac
+VERSION="v0.7.0"
+curl -fsSL "https://github.com/pulumi/schema-tools/releases/download/${VERSION}/schema-tools-${VERSION}-${OS}-${ARCH}.tar.gz" \
+  -o /tmp/schema-tools.tar.gz
+tar -xzf /tmp/schema-tools.tar.gz -C /tmp/
+chmod +x /tmp/schema-tools
+```
+
+**Run and save to a file:**
+
+```shell
+/tmp/schema-tools compare -p {provider} -o v{current_version} -n v{target_version} --json > /tmp/{provider}-schema-diff.json
+```
+
+The `-o` and `-n` flags must be full version tags (e.g., `v6.0.0`, `v7.0.0`), not just
+major numbers. Use the exact versions from the lockfile.
+
+**Useful queries:**
+
+```shell
+# Summary of all breaking change categories
+jq '.summary' /tmp/{provider}-schema-diff.json
+
+# Changes for a specific resource
+jq '.grouped.resources["aws:s3/bucket:Bucket"]' /tmp/{provider}-schema-diff.json
+
+# All changes of a specific type
+jq '[.changes[] | select(.kind == "missing-input")]' /tmp/{provider}-schema-diff.json
+
+# All breaking changes matching a pattern
+jq '[.changes[] | select(.token | test("apigateway"))]' /tmp/{provider}-schema-diff.json
+
+# List all affected resource tokens
+jq '[.changes[] | .token] | unique' /tmp/{provider}-schema-diff.json
+```
+
+Each change entry has `kind`, `token`, `severity`, and `message` fields. The change
+kinds you'll encounter most often during upgrades:
+
+- **missing-input** - a property was removed from inputs. Usually renamed or replaced by
+  a different property with a different shape. The schema diff says it's gone but doesn't
+  say what replaced it - check the upgrade guide or new schema for the replacement.
+- **type-changed** - a property's type changed. The most common pattern is a MaxItemsOne
+  flip: a property is renamed AND changes between single object and array (or vice versa).
+  Example: `certificateAuthorities` (array) -> `certificateAuthority` (single object).
+- **token-remapped** - a resource or function was renamed. If "deprecated," the old name
+  still works (don't chase it). If "remapped," the old name is gone - rename in code and
+  add an alias to preserve state: `aliases: [{ type: "old:token:Name" }]`.
+
+**When to use:** When preview errors mention unknown properties, missing fields, type
+mismatches, or unrecognized resource types. The schema diff tells you exactly what was
+renamed, removed, or reshaped.
+
+## resource_search - scope changes to this stack
+
+Query the stack's deployed resource types. Essential for large providers - filter the
+schema diff to only resources that matter.
+
+```shell
+# Filter schema diff to only resource types in the stack
+jq '[.changes[] | select(.token | test("ZoneSettingsOverride|PageRule|Record|Zone"))]' \
+  /tmp/{provider}-schema-diff.json
+```
+
+**When to use:** Always use alongside schema-tools.
+
+## SDK type definitions - inspect the new API shape
+
+For TypeScript and Python projects, the installed package's type definitions show the
+exact new API - property names, types, required vs. optional.
+
+**TypeScript:** read `node_modules/@pulumi/{provider}/*.d.ts` for the resource type
+**Python:** read the installed package source
+
+Faster than schema-tools for answering "what does this resource look like now?"
+
+## GitHub issues
+
+Search `pulumi/pulumi-{provider}` and `hashicorp/terraform-provider-{tf-name}` for
+specific error messages or resource names.
+
+**When to use:** When upgrade guides don't cover an edge case, or when you're seeing
+unexpected behavior that might be a known bug.

--- a/authoring/skills/provider-upgrade/references/diagnostic-toolbox.md
+++ b/authoring/skills/provider-upgrade/references/diagnostic-toolbox.md
@@ -33,6 +33,10 @@ types actually present in the stack.
 
 **Install** (if not available):
 
+This example is intentionally lightweight and may drift over time. If the pinned version
+below is stale, use the latest available `schema-tools` release instead of treating the
+example version as authoritative.
+
 ```shell
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)

--- a/authoring/skills/provider-upgrade/references/diagnostic-toolbox.md
+++ b/authoring/skills/provider-upgrade/references/diagnostic-toolbox.md
@@ -17,19 +17,19 @@ no-op" - a diff that shows in preview but resolves on `pulumi up` without affect
 real infrastructure.
 
 **Pulumi upgrade guide:**
-`web_search` for `site:pulumi.com {provider} migration guide v{major}`
+Search for `site:pulumi.com {provider} migration guide v{major}`.
 
 **Terraform upgrade guide** (for Terraform-based providers):
 Check `https://registry.terraform.io/providers/{org}/{tf-provider}/latest/docs/guides/version-{major}-upgrade`
-or `web_search` for `site:registry.terraform.io {tf-provider} version {major} upgrade`
+or search for `site:registry.terraform.io {tf-provider} version {major} upgrade`.
 
 **When to use:** For any major version upgrade. Check it early.
 
 ## schema-tools - structured diff between versions
 
 A structured diff of every schema change between provider versions. For large providers,
-the diff can contain thousands of changes - always cross-reference with `resource_search`
-to filter to resources actually in the stack.
+the diff can contain thousands of changes - always cross-reference with the resource
+types actually present in the stack.
 
 **Install** (if not available):
 
@@ -89,13 +89,19 @@ kinds you'll encounter most often during upgrades:
 mismatches, or unrecognized resource types. The schema diff tells you exactly what was
 renamed, removed, or reshaped.
 
-## resource_search - scope changes to this stack
+## Stack state inspection - scope changes to this stack
 
-Query the stack's deployed resource types. Essential for large providers - filter the
-schema diff to only resources that matter.
+Inspect the stack's deployed resource types. Essential for large providers - filter the
+schema diff to only resources that matter. Use whatever state inspection tooling is
+available in the environment, such as `pulumi stack --show-urns`, `pulumi stack export`,
+state files, or backend resource inventory APIs.
 
 ```shell
-# Filter schema diff to only resource types in the stack
+# Example: list resource types from a stack export
+pulumi stack export > /tmp/stack.json
+jq -r '.deployment.resources[].type' /tmp/stack.json | sort -u
+
+# Then filter schema diff to only resource types in the stack
 jq '[.changes[] | select(.token | test("ZoneSettingsOverride|PageRule|Record|Zone"))]' \
   /tmp/{provider}-schema-diff.json
 ```

--- a/authoring/skills/provider-upgrade/use_cases.yaml
+++ b/authoring/skills/provider-upgrade/use_cases.yaml
@@ -6,6 +6,8 @@ queries:
   - "Bump the pulumi-azure-native provider to v3 in my TypeScript project"
   - "Upgrade pulumi-kubernetes from v3 to v4 across my stacks"
   - "Update my GCP provider to the latest version"
+  - "Upgrade the Pulumi Cloudflare provider in this repo"
+  - "Help me bump the Datadog provider without changing real infrastructure"
 
   # Breaking changes / migration
   - "What are the breaking changes when upgrading pulumi-aws from v5 to v6?"
@@ -13,6 +15,8 @@ queries:
   - "The aws provider upgrade broke my S3 bucket resource, how do I fix it?"
   - "After upgrading pulumi-aws, my preview shows resource replacements I didn't expect"
   - "How do I add an alias for a renamed resource after a provider major version bump?"
+  - "My provider upgrade preview shows a create for infrastructure that already exists"
+  - "How do I handle deletes after a Pulumi provider major version upgrade?"
 
   # Dependency management
   - "How do I update @pulumi/aws to a newer version in my npm project?"


### PR DESCRIPTION
## Summary
- replace the existing draft `provider-upgrade` skill with the fuller version from `pulumi-service` and add the `references/diagnostic-toolbox.md` reference doc
- generalize the skill content for this repo by removing Neo-specific tool assumptions, expanding the routing examples, and documenting the skill in `README.md`, `AGENTS.md`, and the authoring plugin metadata
- switch the preview guidance to direct CLI usage with `pulumi preview --refresh --run-program`

## Testing
- not run (repo test suites require `ANTHROPIC_API_KEY`)
- validated `authoring/.claude-plugin/plugin.json` parses successfully