### PR TITLE
Fix skill routing overlap between package-usage and provider-upgrade

### DIFF
--- a/authoring/skills/package-usage/SKILL.md
+++ b/authoring/skills/package-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: package-usage
-description: Track which stacks use a specific Pulumi package and at what versions, or upgrade a stack to the latest version of a package. Use when users ask about package version tracking, outdated package versions across stacks, upgrade candidates, or package usage audits. Also use when users want to upgrade/update a specific package version in a stack or project. Do NOT use for general infrastructure creation, resource provisioning, or questions about how to use a package.
+description: Track which stacks across a Pulumi organization use a specific package and at what versions. Use for cross-stack audits, identifying outdated or unmaintained package versions across many stacks, finding affected stacks before publishing breaking changes to a component package, or planning coordinated upgrade rollouts. Do NOT use for upgrading a cloud provider package (pulumi-aws, pulumi-azure-native, pulumi-gcp, pulumi-kubernetes, etc.) in a single project — use skill `provider-upgrade` instead. Do NOT use for general infrastructure creation, resource provisioning, or how-to questions about a package.
 ---
 
 ## API Reference
@@ -30,16 +30,6 @@ Use when the user wants to know which stacks are using an outdated version of a 
 2. Get stack usage for the package
 3. Compare each stack's `version` against the latest to identify outdated stacks
 
-## Workflow: Upgrade a package in a stack
+## Out of scope: upgrading a specific stack
 
-Use when the user wants to upgrade a specific stack/project to the latest version of a package.
-
-1. Get the latest version of the package
-2. Clone the stack's project repository. If the repository cannot be cloned or the agent lacks filesystem/git access, surface the required change as a diff or instruction set for the user to apply manually.
-3. Detect the project language from the `runtime` field in `Pulumi.yaml`, then update the correct dependency file:
-   - `nodejs` → `package.json`
-   - `python` → `requirements.txt` or `pyproject.toml`
-   - `go` → `go.mod`
-   - `yaml` → `Pulumi.yaml`
-4. Run `pulumi preview` to catch any breaking changes introduced by the version bump before merging.
-5. Open a pull request with the change
+This skill identifies outdated stacks. It does not perform the upgrade itself. For actually bumping a package version in a project — editing `package.json`, `requirements.txt`, `pyproject.toml`, `go.mod`, or `Pulumi.yaml`, running `pulumi preview`, and reconciling the diff — hand off to the `provider-upgrade` skill.

--- a/authoring/skills/provider-upgrade/SKILL.md
+++ b/authoring/skills/provider-upgrade/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: provider-upgrade
 description: >
-  Upgrade any Pulumi provider to a newer version. Use when users explicitly want to upgrade or
-  update a provider, update provider dependencies, check for breaking changes, or bump provider
-  versions in their code. This applies to all providers (aws, azure-native, gcp, kubernetes,
-  aws-native, cloudflare, datadog, etc.) - not just Tier 1 providers. Do NOT use for just
-  querying which stacks use what versions. Use skill `package-usage` for version audits and
-  affected-stack discovery. Do NOT use for general infrastructure tasks.
+  Upgrade any Pulumi provider to a newer version and reconcile the resulting diff. Use when
+  users want to upgrade or update a provider (including editing package.json, requirements.txt,
+  pyproject.toml, go.mod, or Pulumi.yaml to bump a provider SDK), check for breaking changes
+  before or during an upgrade, fix resources that broke after a provider upgrade, or resolve
+  unexpected replacements, creates, or deletes in a post-upgrade preview. Applies to all
+  providers (aws, azure-native, gcp, kubernetes, aws-native, cloudflare, datadog, etc.) — not
+  just Tier 1. Do NOT use for querying which stacks use what package versions; use skill
+  `package-usage` for cross-stack audits. Do NOT use for general infrastructure tasks.
 ---
 
 # Upgrading Pulumi Providers


### PR DESCRIPTION
## Summary

- Tighten `package-usage` description to its unique cross-stack audit scope; explicitly defer single-project provider upgrades to `provider-upgrade`
- Expand `provider-upgrade` description to cover dependency-file edits (package.json, requirements.txt, go.mod, Pulumi.yaml) and post-upgrade breakage (unexpected replacements, creates, deletes)
- Replace `package-usage`'s contradicting "Upgrade a package in a stack" workflow with a hand-off note to `provider-upgrade`

## Why

The `Skill selection accuracy` test for `provider-upgrade` has been failing on `main` at 79% (15/19 passed) since it merged in #21 on 2026-04-01. Four queries were being mis-routed:

| Query | Was picking | Why |
|---|---|---|
| "Upgrade pulumi-kubernetes from v3 to v4 across my stacks" | `package-usage` | Overlap + "across my stacks" |
| "How do I update @pulumi/aws to a newer version in my npm project?" | `package-usage` | Overlap |
| "Update the pulumi_aws dependency in my Python requirements.txt" | `package-usage` | Overlap |
| "The aws provider upgrade broke my S3 bucket resource, how do I fix it?" | `pulumi-best-practices` | `provider-upgrade` didn't mention post-upgrade breakage |

Root cause was a genuine scope overlap: `package-usage` claimed "upgrade/update a specific package version in a stack or project" and even had a full upgrade workflow in its body — exactly the scope that belongs to `provider-upgrade`. No `use_cases.yaml` changes were needed; these are real user phrasings and should route correctly.

The failure didn't block #21 from merging because `Skill selection accuracy` isn't a required status check. A follow-up branch-protection change will fix that.

## Test plan

- [x] `uv run pytest tests/ -n 8` → all 22 tests pass locally
- [x] `provider-upgrade` routing: 19/19 (was 15/19)
- [x] `package-usage` and `pulumi-best-practices` routing: still passing
- [x] `package-usage` quality review: passes (previously contradicted itself after description tightening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)