### PR TITLE
Add Codex plugin compatibility

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,31 @@
+{
+  "name": "pulumi-agent-skills",
+  "interface": {
+    "displayName": "Pulumi Agent Skills",
+    "shortDescription": "Official Pulumi agent skills for infrastructure as code workflows"
+  },
+  "plugins": [
+    {
+      "name": "pulumi-migration",
+      "source": {
+        "source": "local",
+        "path": "./migration"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Coding"
+    },
+    {
+      "name": "pulumi-authoring",
+      "source": {
+        "source": "local",
+        "path": "./authoring"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,21 @@ on:
     branches: [main]
 
 jobs:
+  manifests:
+    name: Plugin manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run tests
+        run: uv run pytest tests/test_manifests.py -v --tb=short
+
   skill-selection:
     name: Skill selection accuracy
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,14 @@ Skills for writing quality Pulumi programs, components, automation, and secrets 
 /plugin install pulumi-authoring
 ```
 
+### OpenAI Codex
+
+```bash
+codex plugin marketplace add pulumi/agent-skills
+```
+
+After the marketplace registers, install plugins from the Codex TUI: run `codex`, open the plugin marketplace, and pick `pulumi-migration` or `pulumi-authoring`.
+
 ### Universal (all agents)
 
 Install all skills:
@@ -96,7 +104,11 @@ Example:
 
 ## Testing
 
-The `tests/` directory contains two pytest-based test suites. Both require `ANTHROPIC_API_KEY` and run automatically on every pull request via `.github/workflows/tests.yml`.
+The `tests/` directory contains three pytest-based test suites that run automatically on every pull request via `.github/workflows/tests.yml`. Two require `ANTHROPIC_API_KEY`; the manifest test runs offline.
+
+### Manifest validation (`test_manifests.py`)
+
+Validates that each plugin manifest (`<plugin>/.claude-plugin/plugin.json` and `<plugin>/.codex-plugin/plugin.json`) parses, has the required fields, and that the marketplace catalogs reference plugin directories that actually exist. Runs offline and gates PRs from forks before the LLM-driven jobs.
 
 ### Skill routing accuracy (`test_skill_selection_accuracy.py`)
 
@@ -152,15 +164,19 @@ The skill will automatically be included in its plugin group. No manifest update
 
 ## Creating a New Plugin Group
 
+Each plugin group ships a manifest for both Claude Code and OpenAI Codex. The skill content is shared; only the per-ecosystem manifest files differ.
+
 1. Create the plugin directory structure:
    ```
    <plugin-name>/
    ├── .claude-plugin/
    │   └── plugin.json
+   ├── .codex-plugin/
+   │   └── plugin.json
    └── skills/
    ```
 
-2. Create `plugin.json`:
+2. Create the Claude manifest at `<plugin-name>/.claude-plugin/plugin.json`:
    ```json
    {
      "name": "pulumi-<plugin-name>",
@@ -174,7 +190,28 @@ The skill will automatically be included in its plugin group. No manifest update
    }
    ```
 
-3. Add an entry to [.claude-plugin/marketplace.json](.claude-plugin/marketplace.json):
+3. Create the Codex manifest at `<plugin-name>/.codex-plugin/plugin.json`. The fields mirror the Claude manifest with two additions: `skills` points at the skills directory, and `interface` holds TUI presentation metadata.
+   ```json
+   {
+     "name": "pulumi-<plugin-name>",
+     "version": "1.0.0",
+     "description": "Plugin description",
+     "skills": "./skills/",
+     "author": { "name": "Pulumi", "url": "https://github.com/pulumi" },
+     "homepage": "https://www.pulumi.com/docs/",
+     "repository": "https://github.com/pulumi/agent-skills",
+     "license": "Apache-2.0",
+     "keywords": ["pulumi", "..."],
+     "interface": {
+       "displayName": "Display Name",
+       "shortDescription": "One-line summary",
+       "developerName": "Pulumi",
+       "category": "Coding"
+     }
+   }
+   ```
+
+4. Add an entry to [.claude-plugin/marketplace.json](.claude-plugin/marketplace.json):
    ```json
    {
      "name": "pulumi-<plugin-name>",
@@ -184,9 +221,19 @@ The skill will automatically be included in its plugin group. No manifest update
    }
    ```
 
-4. Add skills to `<plugin-name>/skills/`
-5. Update this AGENTS.md and README.md
-6. Submit a pull request
+5. Add an entry to [.agents/plugins/marketplace.json](.agents/plugins/marketplace.json) (the Codex marketplace catalog):
+   ```json
+   {
+     "name": "pulumi-<plugin-name>",
+     "source": { "source": "local", "path": "./<plugin-name>" },
+     "policy": { "installation": "AVAILABLE" },
+     "category": "Coding"
+   }
+   ```
+
+6. Add skills to `<plugin-name>/skills/`
+7. Update this AGENTS.md and README.md
+8. Submit a pull request
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Write quality Pulumi programs, components, automation, and secrets management:
 /plugin install pulumi-authoring     # Install authoring skills
 ```
 
+### OpenAI Codex
+
+```bash
+codex plugin marketplace add pulumi/agent-skills
+```
+
+Once the marketplace is registered, install plugins from the Codex TUI: run `codex`, open the plugin marketplace, and pick `pulumi-migration` or `pulumi-authoring`.
+
 ### Universal (all agents)
 
 Install all skills:

--- a/authoring/.codex-plugin/plugin.json
+++ b/authoring/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "pulumi-authoring",
+  "version": "1.0.0",
+  "description": "Write quality Pulumi programs, components, automation, secrets management with ESC, and provider upgrades",
+  "skills": "./skills/",
+  "author": {
+    "name": "Pulumi",
+    "url": "https://github.com/pulumi"
+  },
+  "homepage": "https://www.pulumi.com/docs/",
+  "repository": "https://github.com/pulumi/agent-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "pulumi",
+    "best-practices",
+    "component",
+    "automation-api",
+    "provider-upgrade",
+    "esc",
+    "secrets",
+    "configuration",
+    "upgrade-provider",
+    "upstream-patches"
+  ],
+  "interface": {
+    "displayName": "Pulumi Authoring",
+    "shortDescription": "Best practices and patterns for authoring Pulumi programs",
+    "developerName": "Pulumi",
+    "category": "Coding",
+    "websiteURL": "https://www.pulumi.com/docs/",
+    "defaultPrompt": [
+      "Use $pulumi-best-practices to review this Pulumi code",
+      "Use $pulumi-component to build a reusable Pulumi component",
+      "Use $pulumi-esc to manage configuration and secrets"
+    ]
+  }
+}

--- a/migration/.codex-plugin/plugin.json
+++ b/migration/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "pulumi-migration",
+  "version": "1.0.0",
+  "description": "Convert and import infrastructure from Terraform, CDK, ARM, and CloudFormation to Pulumi",
+  "skills": "./skills/",
+  "author": {
+    "name": "Pulumi",
+    "url": "https://github.com/pulumi"
+  },
+  "homepage": "https://www.pulumi.com/docs/",
+  "repository": "https://github.com/pulumi/agent-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "pulumi",
+    "terraform",
+    "cdk",
+    "arm",
+    "cloudformation",
+    "migration",
+    "import"
+  ],
+  "interface": {
+    "displayName": "Pulumi Migration",
+    "shortDescription": "Migrate Terraform, CDK, ARM, and CloudFormation to Pulumi",
+    "developerName": "Pulumi",
+    "category": "Coding",
+    "websiteURL": "https://www.pulumi.com/docs/",
+    "defaultPrompt": [
+      "Use $pulumi-terraform-to-pulumi to convert this Terraform module",
+      "Use $pulumi-cdk-to-pulumi to migrate this CDK app",
+      "Use $cloudformation-to-pulumi to migrate this CloudFormation stack"
+    ]
+  }
+}

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,0 +1,99 @@
+"""
+Validate plugin manifests for Claude Code and Codex.
+
+Checks that every plugin.json parses, has the fields each ecosystem requires,
+and that marketplace catalogs reference plugin directories that actually exist.
+
+Run with:
+    uv run pytest tests/test_manifests.py -v
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+
+CODEX_REQUIRED_FIELDS = ("name", "version", "description", "skills")
+CLAUDE_REQUIRED_FIELDS = ("name", "version", "description")
+
+
+def _codex_manifests() -> list[Path]:
+    return sorted(REPO_ROOT.glob("*/.codex-plugin/plugin.json"))
+
+
+def _claude_manifests() -> list[Path]:
+    return sorted(REPO_ROOT.glob("*/.claude-plugin/plugin.json"))
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+@pytest.mark.parametrize("manifest", _codex_manifests(), ids=_rel)
+def test_codex_plugin_manifest(manifest: Path) -> None:
+    data = json.loads(manifest.read_text())
+    for field in CODEX_REQUIRED_FIELDS:
+        assert field in data, f"{_rel(manifest)}: missing field `{field}`"
+    skills_path = (manifest.parent.parent / data["skills"].lstrip("./")).resolve()
+    assert skills_path.is_dir(), (
+        f"{_rel(manifest)}: skills path `{data['skills']}` does not resolve to a directory"
+    )
+
+
+@pytest.mark.parametrize("manifest", _claude_manifests(), ids=_rel)
+def test_claude_plugin_manifest(manifest: Path) -> None:
+    data = json.loads(manifest.read_text())
+    for field in CLAUDE_REQUIRED_FIELDS:
+        assert field in data, f"{_rel(manifest)}: missing field `{field}`"
+
+
+def test_codex_marketplace() -> None:
+    marketplace = REPO_ROOT / ".agents" / "plugins" / "marketplace.json"
+    if not marketplace.exists():
+        pytest.skip("Codex marketplace.json not present")
+    data = json.loads(marketplace.read_text())
+    plugins = data.get("plugins", [])
+    assert plugins, f"{_rel(marketplace)}: no plugins listed"
+    for entry in plugins:
+        name = entry["name"]
+        source = entry["source"]
+        assert source.get("source") == "local", (
+            f"{_rel(marketplace)}: plugin {name} uses unsupported source `{source.get('source')}`; "
+            "this test only validates `local` sources"
+        )
+        plugin_dir = (REPO_ROOT / source["path"].lstrip("./")).resolve()
+        plugin_manifest = plugin_dir / ".codex-plugin" / "plugin.json"
+        assert plugin_manifest.exists(), (
+            f"{_rel(marketplace)}: plugin {name} points at `{source['path']}` "
+            f"but `{plugin_manifest.relative_to(REPO_ROOT)}` does not exist"
+        )
+        manifest_name = json.loads(plugin_manifest.read_text())["name"]
+        assert manifest_name == name, (
+            f"{_rel(marketplace)}: plugin name `{name}` does not match "
+            f"`{plugin_manifest.relative_to(REPO_ROOT)}` name `{manifest_name}`"
+        )
+
+
+def test_claude_marketplace() -> None:
+    marketplace = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+    if not marketplace.exists():
+        pytest.skip("Claude marketplace.json not present")
+    data = json.loads(marketplace.read_text())
+    plugins = data.get("plugins", [])
+    assert plugins, f"{_rel(marketplace)}: no plugins listed"
+    for entry in plugins:
+        name = entry["name"]
+        source = entry["source"]
+        plugin_dir = (REPO_ROOT / source.lstrip("./")).resolve()
+        plugin_manifest = plugin_dir / ".claude-plugin" / "plugin.json"
+        assert plugin_manifest.exists(), (
+            f"{_rel(marketplace)}: plugin {name} points at `{source}` "
+            f"but `{plugin_manifest.relative_to(REPO_ROOT)}` does not exist"
+        )
+        manifest_name = json.loads(plugin_manifest.read_text())["name"]
+        assert manifest_name == name, (
+            f"{_rel(marketplace)}: plugin name `{name}` does not match "
+            f"`{plugin_manifest.relative_to(REPO_ROOT)}` name `{manifest_name}`"
+        )


### PR DESCRIPTION
## Summary

- Adds `.codex-plugin/plugin.json` to both plugin groups so Pulumi skills work natively in OpenAI Codex alongside Claude Code. Skill content is unchanged; only the per-ecosystem manifest layer is new.
- Adds the Codex marketplace catalog at `.agents/plugins/marketplace.json` so users can install via `codex plugin marketplace add pulumi/agent-skills`.
- Adds `tests/test_manifests.py` and a `manifests` CI job that validates every plugin manifest parses, has the required fields, and that marketplace catalogs reference real plugin directories. Runs offline (no API key), so PRs from forks get fast feedback before the LLM-driven jobs.
- Updates README and AGENTS.md with the Codex install command and a parallel walk-through for adding the second manifest type when creating a new plugin group.

## Notes

- Manifest format was verified by direct comparison to OpenAI's reference GitHub plugin shipped in the curated marketplace.
- End-to-end TUI install has not been walked through yet — the marketplace registers cleanly and the JSON validates, but confirming a skill actually activates in a Codex session is still a manual step before merge.