### PR TITLE
feat(authoring): add pulumi-dynamic-to-go-provider skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Skills for writing quality Pulumi programs, components, automation, and secrets 
 - **provider-upgrade**: Safe workflows for upgrading Pulumi providers without unintended infrastructure changes
 - **pulumi-upgrade-provider**: Automate Pulumi provider repo upgrades with the upgrade-provider tool
 - **upstream-patches**: Create, amend, remove, and rebase patches for Terraform provider submodules
+- **pulumi-dynamic-to-go-provider**: Port a TypeScript Pulumi dynamic provider to a pulumi-go-provider-based Go provider using the `infer` package
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Write quality Pulumi programs, components, automation, and secrets management:
 | [provider-upgrade](authoring/skills/provider-upgrade) | Safe workflows for upgrading Pulumi providers without unintended infrastructure changes |
 | [pulumi-upgrade-provider](authoring/skills/pulumi-upgrade-provider) | Automate Pulumi provider repo upgrades |
 | [upstream-patches](authoring/skills/upstream-patches) | Manage upstream Terraform patch stacks in provider repos |
+| [pulumi-dynamic-to-go-provider](authoring/skills/pulumi-dynamic-to-go-provider) | Port a TypeScript dynamic provider to a pulumi-go-provider-based Go provider |
 
 ## Installation
 

--- a/authoring/skills/pulumi-dynamic-to-go-provider/SKILL.md
+++ b/authoring/skills/pulumi-dynamic-to-go-provider/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: pulumi-dynamic-to-go-provider
+description: Port a working TypeScript Pulumi dynamic provider (a class implementing `pulumi.dynamic.ResourceProvider`, used via `pulumi.dynamic.Resource`) to a `pulumi-go-provider`-based Go provider using the `infer` package. Covers resource type translation, the six CRUD method mappings (check/diff/create/read/update/delete), retry helper port, schema generation via `pulumi package gen-sdk`, and consumer-side wiring with a generated SDK. Use when (1) the user has an existing TypeScript dynamic provider and wants to convert it to a distributable Go provider, (2) the user mentions porting from `pulumi.dynamic.ResourceProvider` to `infer.Provider`, (3) the user asks "convert dynamic provider to Go", "port to pulumi-go-provider", "TS dynamic to Go provider migration", or asks how to make a dynamic provider into a real distributable provider.
+---
+
+# Port a TypeScript dynamic provider to pulumi-go-provider
+
+A TS dynamic provider implements `pulumi.dynamic.ResourceProvider` and is
+serialised into program state. A `pulumi-go-provider`-based Go provider runs
+as a long-lived gRPC binary, has a schema, and can produce SDKs for any
+Pulumi-supported language. The port is mostly mechanical, but several traps
+only surface during schema generation or end-to-end runs — this skill walks
+through them in the order they bite.
+
+## What this skill produces
+
+A new directory (typically `go-provider/`) containing:
+
+```text
+go-provider/
+├── go.mod
+├── main.go                 # Config + Configure + provider builder
+├── <resource>.go           # Args + State types + CRUD methods
+├── http_retry.go           # Retry helper (verbatim from assets/)
+├── pulumi-resource-<name>  # Built provider binary
+├── sdk/nodejs/             # Generated TS SDK
+└── examples/typescript/    # Consumer program exercising the SDK
+```
+
+Plus a verification flow that runs the same lifecycle the source TS provider
+ran — `pulumi up`, modify+up (to drive update), out-of-band drift +
+`pulumi refresh`, idempotent destroy.
+
+## Workflow
+
+### Step 1 — Survey the TS source
+
+Read the existing TS dynamic provider end-to-end. Identify:
+
+- The `dynamic.Resource` subclass (the user-facing resource).
+- The `dynamic.ResourceProvider` implementation (the CRUD class).
+- The inputs interface (typically `XxxArgs`).
+- The state shape (what `outs` includes from `create`/`update`/`read`).
+- HTTP/retry helpers.
+- How config (URL, credentials) reaches the CRUD methods — usually closure
+  capture or constructor injection.
+
+For each input field, note its type. Unions like `"low" | "medium" | "high"`
+become Go enums. Optional fields become pointer fields in Go.
+
+For each CRUD method, note the implementation strategy:
+
+- Is `create` returning inputs (echo) or server response (server-truth)?
+- Is `update` partial PATCH or full PUT?
+- Does `read` actually fetch or is it a no-op?
+- Does `delete` handle 404 idempotently?
+- What does `check` validate?
+- What does `diff` compare?
+
+These choices port forward as-is; document them before translating so the Go
+side faithfully mirrors the source's contract.
+
+### Step 2 — Initialise the Go module
+
+```bash
+mkdir go-provider && cd go-provider
+go mod init github.com/<org>/<provider-name>
+go get github.com/pulumi/pulumi-go-provider@latest
+```
+
+Copy `assets/http_retry.go` into `go-provider/` verbatim — no per-resource
+customisation needed.
+
+Copy `assets/scaffold-main.go` to `go-provider/main.go` and substitute the
+placeholders (TODO comments mark where).
+
+### Step 3 — Translate types
+
+For the inputs interface, create a Go struct with `pulumi:"name"` tags:
+
+```go
+type XxxArgs struct {
+    Title    string   `pulumi:"title"`
+    Optional *string  `pulumi:"optional,optional"` // pointer + ,optional for optional fields
+    Priority Priority `pulumi:"priority"`           // enum type, see below
+}
+```
+
+For union types, define a typed-string enum with `Values()`:
+
+```go
+type Priority string
+const (
+    PriorityLow    Priority = "low"
+    PriorityMedium Priority = "medium"
+    PriorityHigh   Priority = "high"
+)
+func (Priority) Values() []infer.EnumValue[Priority] {
+    return []infer.EnumValue[Priority]{
+        {Name: "low",    Value: PriorityLow,    Description: "..."},
+        {Name: "medium", Value: PriorityMedium, Description: "..."},
+        {Name: "high",   Value: PriorityHigh,   Description: "..."},
+    }
+}
+```
+
+For the state shape, declare it as a separate struct:
+
+```go
+type XxxState struct {
+    Title    string   `pulumi:"title"`
+    Optional *string  `pulumi:"optional,optional"`
+    Priority Priority `pulumi:"priority"`
+}
+```
+
+**Critical**: do *not* declare an `id` field on State. The framework reserves
+`id` and manages it separately via `CreateResponse.ID` and `req.ID`. If your
+TS state had `outs.id`, that field disappears from the Go state struct — it's
+implicit. This is the first trap that bites; see
+[references/traps.md](references/traps.md).
+
+Implement `Annotate` on each type for descriptions:
+
+```go
+func (a *XxxArgs) Annotate(an infer.Annotator) {
+    an.Describe(&a.Title, "The text of the item.")
+    // ...
+}
+```
+
+For the full per-concept mapping, see
+[references/translation-table.md](references/translation-table.md).
+
+### Step 4 — Translate CRUD methods, in this order
+
+Translate one method at a time, in this order — each builds on the previous,
+running from "least decision-density" to "most":
+
+1. **Read** — fetch from server; return empty `ReadResponse{}` on 404.
+2. **Delete** — fetch DELETE; treat 404 as success (idempotent).
+3. **Create** — POST with body projected to a typed struct (never the input
+   bag wholesale — see traps). POST does *not* go through the retry helper
+   (idempotency).
+4. **Diff** — field-by-field strict equality; populate `DetailedDiff` map.
+5. **Check** — usually trivial; the schema-level enum handles enum
+   validation. Use `infer.DefaultCheck[Args]` and add custom failures if
+   needed.
+6. **Update** — partial PATCH containing only changed fields. Most
+   decision-dense method; see
+   [references/crud-patterns.md](references/crud-patterns.md) for the
+   body-shape choice (`map[string]any` vs pointer struct).
+
+After each method, `go build ./...` to keep yourself honest. Add compile-time
+interface assertions to make missing methods fail at build, not runtime:
+
+```go
+var (
+    _ infer.CustomCheck[XxxArgs]            = (*Xxx)(nil)
+    _ infer.CustomDiff[XxxArgs, XxxState]   = (*Xxx)(nil)
+    _ infer.CustomRead[XxxArgs, XxxState]   = (*Xxx)(nil)
+    _ infer.CustomUpdate[XxxArgs, XxxState] = (*Xxx)(nil)
+    _ infer.CustomDelete[XxxState]          = (*Xxx)(nil)
+)
+```
+
+For the per-method patterns and code sketches, see
+[references/crud-patterns.md](references/crud-patterns.md).
+
+### Step 5 — Schema check + SDK generation
+
+```bash
+go build -o pulumi-resource-<name> .
+pulumi package get-schema ./pulumi-resource-<name>
+```
+
+This is where the `id`-reserved-name trap surfaces if you missed it in
+step 3. Other schema errors (missing required tags, malformed enum) also
+appear here.
+
+Once schema is valid:
+
+```bash
+pulumi package gen-sdk ./pulumi-resource-<name> --language nodejs --out ./sdk
+cd sdk/nodejs && npm install && npm run build
+```
+
+For multi-language SDKs, repeat with `--language python|dotnet|go`.
+
+### Step 6 — Consumer scaffolding
+
+Scaffold the consumer with `pulumi new` for boilerplate
+(tsconfig.json, .gitignore, stub files), then overwrite the three
+skill-specific files:
+
+```bash
+cd go-provider/examples
+pulumi new typescript --generate-only --yes \
+  --name <consumer-name> --dir typescript
+cd typescript
+```
+
+`pulumi new` writes a stub `Pulumi.yaml`, `package.json`, `index.ts`,
+plus tsconfig.json and .gitignore. The first three need overwriting:
+
+| File | What needs to change vs. the stub |
+|---|---|
+| `Pulumi.yaml` | Adds the `plugins: providers:` block pointing at the locally-built binary. Use `assets/consumer-Pulumi.yaml`. |
+| `package.json` | Replaces the stub `@pulumi/pulumi` dep with a `file:` link to the generated SDK at `../../sdk/nodejs`. Use `assets/consumer-package.json`. |
+| `index.ts` | Hand-written: imports the SDK package, reads project config, constructs the Provider and resources. |
+
+The generated SDK's package name is deterministic from main.go:
+
+| Language | Package name |
+|---|---|
+| nodejs | `@<namespace>/<Name>` |
+| python | `<namespace>_<Name>` (underscored, lowercased) |
+| go | `github.com/<namespace>/<Name>/sdk/go/<Name>` |
+| dotnet | `<Pascal-namespace>.<PascalName>` |
+
+Where `<namespace>` is `WithNamespace(...)` and `<Name>` is the
+`const Name` in main.go. So `WithNamespace("rshade") + Name = "todo"`
+produces an nodejs package `@rshade/todo`. You don't need to inspect
+`sdk/<lang>/package.json` to discover it.
+
+Copy the two assets, substitute their placeholders, write `index.ts`,
+then:
+
+```bash
+pulumi install
+pulumi whoami       # confirm logged in to *some* backend; see traps.md
+pulumi stack init dev
+pulumi config set <consumer-name>:<config-key> <value>
+pulumi config set <provider-name>:<config-key> <value>  # see traps.md
+pulumi up
+```
+
+If `pulumi whoami` fails, ask the user which backend they want — never
+run `pulumi login --local` eagerly. It switches the active backend and
+can disconnect a cloud-logged-in user.
+
+`pulumi install` installs both npm dependencies (per the configured
+package manager) and any Pulumi plugins declared in `Pulumi.yaml` — so
+the local provider plugin from the `plugins:` block is resolved in the
+same step.
+
+### Step 7 — Verify end-to-end
+
+Run the same lifecycle the TS source ran:
+
+1. **Create** — `pulumi up`. Confirm resources created, IDs surfaced as
+   stack outputs.
+2. **Update** — modify a field in `index.ts`, run `pulumi up`. Confirm the
+   `[diff: ~field]` annotation; check the server side to confirm partial
+   PATCH (other fields preserved).
+3. **Refresh** — modify a field on the server out-of-band, run
+   `pulumi refresh`. Confirm drift detected and pulled into state.
+4. **Idempotent destroy** — manually delete one resource on the server, run
+   `pulumi destroy`. Confirm `"already deleted on server"` log line; all
+   resources cleaned up.
+
+If all four steps succeed, the port is functionally complete. If any step
+fails, see [references/traps.md](references/traps.md) for likely causes.
+
+For the full verification recipe with sample commands, see
+[references/verification-flow.md](references/verification-flow.md).
+
+## Known traps (load this immediately on encountering errors)
+
+- `"id" is a reserved field name` at schema-gen time → remove `Id` field
+  from State struct.
+- Provider state on the server contains `__provider` blob → stage-1 only;
+  cannot recur in Go (no closure to serialise).
+- "Provider exited prematurely" warning at end of destroy → benign;
+  operations succeeded, framework shutdown handshake quirk.
+- Empty-body crash on retry helper's last attempt → don't
+  `defer res.Body.Close()` inside the retry loop; close in
+  `errorFromResponse` after the body read.
+
+For the full list with detection and fix patterns, see
+[references/traps.md](references/traps.md).
+
+## Resources
+
+| File | Purpose |
+|---|---|
+| [`references/translation-table.md`](references/translation-table.md) | Concept-by-concept mapping from TS dynamic provider to Go infer. Read when stuck on a specific translation. |
+| [`references/crud-patterns.md`](references/crud-patterns.md) | The Go code shape for each CRUD method, with substitution patterns. Read while translating any method. |
+| [`references/traps.md`](references/traps.md) | Known failure modes with detection symptoms and fixes. Read when something goes wrong. |
+| [`references/verification-flow.md`](references/verification-flow.md) | End-to-end test recipe with exact commands. Read for step 7. |
+| `assets/http_retry.go` | Retry helper, copy-paste verbatim. |
+| `assets/scaffold-main.go` | `main.go` template with placeholders for resource type, provider name, namespace. |
+| `assets/consumer-Pulumi.yaml` | Consumer-side `Pulumi.yaml` with `plugins:` block. |
+| `assets/consumer-package.json` | Consumer-side `package.json` with `file:` SDK link. |

--- a/authoring/skills/pulumi-dynamic-to-go-provider/assets/consumer-Pulumi.yaml
+++ b/authoring/skills/pulumi-dynamic-to-go-provider/assets/consumer-Pulumi.yaml
@@ -1,0 +1,25 @@
+# Consumer-side Pulumi.yaml for a TypeScript program that exercises the
+# generated SDK against the locally-built Go provider.
+#
+# The plugins:providers block tells Pulumi where to find the binary
+# instead of looking it up in the registry. The relative path is from
+# this file's directory.
+#
+# TODO: replace the placeholders below.
+
+# TODO: Project name (any string, doesn't have to match the provider name).
+name: <CONSUMER_PROJECT_NAME>
+description: Stage 2 consumer — exercises the Go provider via generated SDK.
+runtime:
+  name: nodejs
+  options:
+    typescript: true
+    packagemanager: npm
+plugins:
+  providers:
+    # <PROVIDER_NAME> must match the const Name in main.go and the
+    # binary name `pulumi-resource-<PROVIDER_NAME>`.
+    # path: relative to this Pulumi.yaml; points at the directory
+    # containing the `pulumi-resource-<PROVIDER_NAME>` binary.
+    - name: <PROVIDER_NAME>
+      path: ../..

--- a/authoring/skills/pulumi-dynamic-to-go-provider/assets/consumer-package.json
+++ b/authoring/skills/pulumi-dynamic-to-go-provider/assets/consumer-package.json
@@ -1,0 +1,18 @@
+{
+  "_comment_TODO": "Replace placeholders. Then delete this _comment field.",
+  "_comment_PROVIDER_NAME": "Substitute <PROVIDER_NAME> with your provider's name (must match main.go's const Name).",
+  "_comment_SDK_NAMESPACE": "<SDK_NAMESPACE>/<PROVIDER_NAME> is whatever the generated SDK's package.json says under 'name'. Run `cat ../../sdk/nodejs/package.json` to check.",
+
+  "name": "<CONSUMER_PROJECT_NAME>",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.ts",
+  "dependencies": {
+    "@pulumi/pulumi": "^3.142.0",
+    "<SDK_NAMESPACE>/<PROVIDER_NAME>": "file:../../sdk/nodejs"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/authoring/skills/pulumi-dynamic-to-go-provider/assets/http_retry.go
+++ b/authoring/skills/pulumi-dynamic-to-go-provider/assets/http_retry.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+// doWithRetry mirrors stage 1's fetchWithRetry: retry on HTTP 5xx, 429, and
+// network errors, with exponential backoff + jitter, capped at maxAttempts.
+//
+// Per E4b, this helper is used only for idempotent methods (GET, PATCH, DELETE).
+// Create's POST goes through client.Do directly to avoid duplicate-create.
+//
+// On the final attempt the response is returned even if the status is in the
+// retry range, so the caller can inspect the body for a meaningful error
+// message. Caller is responsible for closing res.Body.
+func doWithRetry(
+	ctx context.Context,
+	client *http.Client,
+	method, url string,
+	body []byte,
+	maxAttempts int,
+) (*http.Response, error) {
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		var bodyReader io.Reader
+		if body != nil {
+			bodyReader = bytes.NewReader(body)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+		if err != nil {
+			return nil, fmt.Errorf("build %s %s: %w", method, url, err)
+		}
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		res, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt < maxAttempts-1 {
+				if waitErr := waitBackoff(ctx, attempt); waitErr != nil {
+					return nil, waitErr
+				}
+				continue
+			}
+			return nil, fmt.Errorf("%s %s: %w", method, url, err)
+		}
+
+		isRetryable := res.StatusCode == http.StatusTooManyRequests ||
+			(res.StatusCode >= 500 && res.StatusCode < 600)
+		if isRetryable && attempt < maxAttempts-1 {
+			lastErr = fmt.Errorf("HTTP %d %s", res.StatusCode, res.Status)
+			res.Body.Close()
+			if waitErr := waitBackoff(ctx, attempt); waitErr != nil {
+				return nil, waitErr
+			}
+			continue
+		}
+		return res, nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("doWithRetry exhausted %d attempts", maxAttempts)
+	}
+	return nil, lastErr
+}
+
+// waitBackoff sleeps for an exponentially-increasing duration with jitter,
+// honouring ctx cancellation so a destroy mid-flight wakes up early.
+func waitBackoff(ctx context.Context, attempt int) error {
+	base := 200 * time.Millisecond * time.Duration(1<<attempt)
+	jitter := time.Duration(rand.Int63n(int64(base) / 3)) //nolint:gosec // jitter
+	d := base + jitter
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// errorFromResponse mirrors stage 1's errorFromResponse: format an error with
+// method, URL, status, and as much of the response body as is available.
+//
+// Reads (and closes) res.Body; do not use res after calling this.
+func errorFromResponse(method, url string, res *http.Response) error {
+	defer res.Body.Close()
+	body, readErr := io.ReadAll(res.Body)
+	bodyStr := string(body)
+	if readErr != nil {
+		bodyStr = "<failed to read body: " + readErr.Error() + ">"
+	}
+	if bodyStr == "" {
+		bodyStr = "<no body>"
+	}
+	return fmt.Errorf(
+		"%s %s failed: %d %s\nResponse body: %s",
+		method, url, res.StatusCode, res.Status, bodyStr,
+	)
+}

--- a/authoring/skills/pulumi-dynamic-to-go-provider/assets/scaffold-main.go
+++ b/authoring/skills/pulumi-dynamic-to-go-provider/assets/scaffold-main.go
@@ -1,0 +1,98 @@
+// Scaffold for the provider's main.go.
+//
+// Substitute the placeholders marked with TODO comments. The shape is
+// stable across most ports — Config + Configure + provider builder.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// TODO: Bump on any schema-affecting change.
+const Version = "0.1.0"
+
+// TODO: Set this to your provider's plugin name. The binary the engine
+// looks for is `pulumi-resource-<Name>`. Example: "todo", "myapi".
+const Name = "<PROVIDER_NAME>"
+
+// Config holds provider-level configuration.
+//
+// Field naming convention:
+//   - Exported fields with `pulumi:"name"` tags are user-supplied
+//     configuration values that show up in the schema.
+//   - Unexported fields (lowercase) are internal runtime state populated
+//     by Configure; they are skipped by introspection and stay out of
+//     the schema.
+//
+// TODO: Add user-supplied config fields here (URLs, API keys, etc.).
+//   Example:
+//     ServerUrl string `pulumi:"serverUrl"`
+//     ApiKey    string `pulumi:"apiKey" provider:"secret"`  // marks as secret
+type Config struct {
+	// TODO: Replace with your config fields.
+	ServerUrl string `pulumi:"serverUrl"`
+
+	// Internal runtime state — populated by Configure, not part of schema.
+	client *http.Client
+}
+
+// Annotate adds descriptions to config fields. They appear in the schema
+// and propagate to generated SDK docs.
+func (c *Config) Annotate(a infer.Annotator) {
+	// TODO: Describe each config field.
+	a.Describe(&c.ServerUrl, "Base URL of the upstream API.")
+}
+
+// Configure runs once at provider startup, after user config is unmarshalled
+// but before any CRUD method is called. Initialise long-lived state here
+// (HTTP clients, loggers, validated derived values, etc.).
+//
+// State set on c here is shared across all goroutines; it must be
+// goroutine-safe. *http.Client is fine. A non-thread-safe cache wouldn't be.
+func (c *Config) Configure(_ context.Context) error {
+	c.client = &http.Client{Timeout: 30 * time.Second}
+	// TODO: Validate config (e.g., parse URL, check required fields).
+	return nil
+}
+
+func main() {
+	provider, err := buildProvider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build provider: %s\n", err)
+		os.Exit(1)
+	}
+	if err := provider.Run(context.Background(), Name, Version); err != nil {
+		fmt.Fprintf(os.Stderr, "run provider: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func buildProvider() (p.Provider, error) {
+	return infer.NewProviderBuilder().
+		// TODO: Set the namespace. Affects schema's "namespace" field.
+		WithNamespace("<NAMESPACE>").
+		// TODO: One-line description of what the provider does.
+		WithDescription("<PROVIDER_DESCRIPTION>").
+		WithConfig(infer.Config(&Config{})).
+		WithResources(
+			// TODO: Register each resource type. Replace `&Xxx{}` with
+			//       your resource's value. Add more lines for additional
+			//       resources.
+			infer.Resource(&Xxx{}),
+		).
+		WithModuleMap(map[tokens.ModuleName]tokens.ModuleName{
+			// Maps the Go package name to the SDK module name (`index` is
+			// the conventional default for single-package providers).
+			"main": "index",
+		}).
+		Build()
+}

--- a/authoring/skills/pulumi-dynamic-to-go-provider/references/crud-patterns.md
+++ b/authoring/skills/pulumi-dynamic-to-go-provider/references/crud-patterns.md
@@ -1,0 +1,331 @@
+# CRUD method patterns for `pulumi-go-provider` (`infer`) v1.x
+
+Code patterns for each CRUD method, in the recommended translation order.
+Each pattern shows the method signature, the typical body shape, and what to
+substitute (`<placeholder>` markers).
+
+Assumptions baked in:
+
+- The provider's resource type is `Xxx` (a `struct{}`).
+- Inputs are `XxxArgs`, state is `XxxState`.
+- Config is `Config{ ServerUrl string; client *http.Client }`.
+- The retry helper is `doWithRetry(ctx, client, method, url, body, maxAttempts)`
+  from `assets/http_retry.go`.
+- Errors are formatted by `errorFromResponse(method, url, res)`.
+
+## Translation order
+
+Translate methods in this order — each builds on the previous:
+
+1. **Read** — simplest; baseline pattern for HTTP + state shape
+2. **Delete** — adds idempotent-on-404
+3. **Create** — adds POST without retry, body projection discipline
+4. **Diff** — pure logic, no HTTP
+5. **Check** — usually trivial with schema-level enum
+6. **Update** — most decision-density (partial body shape)
+
+After writing each method, `go build ./...` to keep yourself honest. Add the
+compile-time interface assertions early (they fail loudly when a method
+signature drifts).
+
+## Read
+
+```go
+func (*Xxx) Read(
+    ctx context.Context,
+    req infer.ReadRequest[XxxArgs, XxxState],
+) (infer.ReadResponse[XxxArgs, XxxState], error) {
+    cfg := infer.GetConfig[Config](ctx)
+    url := cfg.ServerUrl + "/<resource-path>/" + req.ID
+
+    res, err := doWithRetry(ctx, cfg.client, http.MethodGet, url, nil, 3)
+    if err != nil {
+        return infer.ReadResponse[XxxArgs, XxxState]{}, err
+    }
+    if res.StatusCode == http.StatusNotFound {
+        res.Body.Close()
+        // Empty response signals "resource gone" — engine drops from state.
+        return infer.ReadResponse[XxxArgs, XxxState]{}, nil
+    }
+    if res.StatusCode < 200 || res.StatusCode >= 300 {
+        return infer.ReadResponse[XxxArgs, XxxState]{}, errorFromResponse("GET", url, res)
+    }
+    defer res.Body.Close()
+
+    var current <serverObjectType>
+    if err := json.NewDecoder(res.Body).Decode(&current); err != nil {
+        return infer.ReadResponse[XxxArgs, XxxState]{}, fmt.Errorf("decode GET response: %w", err)
+    }
+
+    state := stateFromServerObject(current)
+    return infer.ReadResponse[XxxArgs, XxxState]{
+        ID:     req.ID,
+        Inputs: argsFromState(state),
+        State:  state,
+    }, nil
+}
+```
+
+The `<serverObjectType>` is a struct that mirrors what the upstream API
+returns on GET. Often identical to `XxxState` plus an `Id` field; sometimes
+different (extra metadata).
+
+## Delete
+
+```go
+func (*Xxx) Delete(
+    ctx context.Context,
+    req infer.DeleteRequest[XxxState],
+) (infer.DeleteResponse, error) {
+    cfg := infer.GetConfig[Config](ctx)
+    url := cfg.ServerUrl + "/<resource-path>/" + req.ID
+
+    res, err := doWithRetry(ctx, cfg.client, http.MethodDelete, url, nil, 3)
+    if err != nil {
+        return infer.DeleteResponse{}, err
+    }
+    if res.StatusCode == http.StatusNotFound {
+        res.Body.Close()
+        p.GetLogger(ctx).Warningf("<resource> %q already deleted on server", req.ID)
+        return infer.DeleteResponse{}, nil
+    }
+    if res.StatusCode < 200 || res.StatusCode >= 300 {
+        return infer.DeleteResponse{}, errorFromResponse("DELETE", url, res)
+    }
+    res.Body.Close()
+    return infer.DeleteResponse{}, nil
+}
+```
+
+Where `p` is the framework's top-level package (`p "github.com/pulumi/pulumi-go-provider"`).
+
+## Create
+
+```go
+func (*Xxx) Create(
+    ctx context.Context,
+    req infer.CreateRequest[XxxArgs],
+) (infer.CreateResponse[XxxState], error) {
+    cfg := infer.GetConfig[Config](ctx)
+
+    if req.DryRun {
+        // Preview: don't hit the server; reflect inputs as state.
+        return infer.CreateResponse[XxxState]{
+            Output: stateFromArgs(req.Inputs),
+        }, nil
+    }
+
+    // Project inputs to a typed body — never send the input bag wholesale.
+    body, err := json.Marshal(bodyFromArgs(req.Inputs))
+    if err != nil {
+        return infer.CreateResponse[XxxState]{}, fmt.Errorf("marshal body: %w", err)
+    }
+
+    url := cfg.ServerUrl + "/<resource-path>"
+    httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+    if err != nil {
+        return infer.CreateResponse[XxxState]{}, fmt.Errorf("build POST %s: %w", url, err)
+    }
+    httpReq.Header.Set("Content-Type", "application/json")
+
+    // POST does NOT go through doWithRetry — non-idempotent (E4b rule).
+    res, err := cfg.client.Do(httpReq)
+    if err != nil {
+        return infer.CreateResponse[XxxState]{}, fmt.Errorf("POST %s: %w", url, err)
+    }
+    if res.StatusCode < 200 || res.StatusCode >= 300 {
+        return infer.CreateResponse[XxxState]{}, errorFromResponse("POST", url, res)
+    }
+    defer res.Body.Close()
+
+    var created <serverObjectType>
+    if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+        return infer.CreateResponse[XxxState]{}, fmt.Errorf("decode POST response: %w", err)
+    }
+
+    return infer.CreateResponse[XxxState]{
+        ID:     created.Id,
+        Output: stateFromServerObject(created),
+    }, nil
+}
+```
+
+Helpers:
+
+- `bodyFromArgs(args XxxArgs) <bodyType>` — typed body struct (only the
+  fields the API accepts; never includes `id` or framework internals).
+- `stateFromArgs(args XxxArgs) XxxState` — used in DryRun to skip the network
+  but return a sensible state.
+- `stateFromServerObject(obj <serverObjectType>) XxxState` — converts the
+  server's response shape to the state struct.
+
+## Diff
+
+```go
+func (*Xxx) Diff(
+    _ context.Context,
+    req infer.DiffRequest[XxxArgs, XxxState],
+) (infer.DiffResponse, error) {
+    diff := map[string]p.PropertyDiff{}
+    if req.Inputs.Title != req.State.Title {
+        diff["title"] = p.PropertyDiff{Kind: p.Update}
+    }
+    if req.Inputs.<Field2> != req.State.<Field2> {
+        diff["<field2>"] = p.PropertyDiff{Kind: p.Update}
+    }
+    // ... one block per field
+    return infer.DiffResponse{
+        HasChanges:   len(diff) > 0,
+        DetailedDiff: diff,
+    }, nil
+}
+```
+
+Use `p.UpdateReplace` instead of `p.Update` for fields that should trigger
+replace (delete + create) rather than in-place update.
+
+**Avoid reflect-based field iteration.** It re-introduces the phantom-field
+risk: server-added fields land in `req.State` but not in `req.Inputs`, and
+reflection-based equality reports a phantom diff every refresh. Stick to
+explicit `if` blocks per known field.
+
+## Check
+
+```go
+func (*Xxx) Check(
+    ctx context.Context,
+    req infer.CheckRequest,
+) (infer.CheckResponse[XxxArgs], error) {
+    args, failures, err := infer.DefaultCheck[XxxArgs](ctx, req.NewInputs)
+    if err != nil {
+        return infer.CheckResponse[XxxArgs]{Inputs: args, Failures: failures}, err
+    }
+
+    // Add custom validation that the schema can't express:
+    if args.Title == "" {
+        failures = append(failures, p.CheckFailure{
+            Property: "title",
+            Reason:   "title must be a non-empty string",
+        })
+    }
+
+    return infer.CheckResponse[XxxArgs]{Inputs: args, Failures: failures}, nil
+}
+```
+
+If you have a typed-string enum (`type Priority string` with `Values()`), the
+schema rejects bad enum values *before* `Check` runs. Manual enum validation
+in `Check` becomes near-redundant — keep it only if explicit comparison
+artefact-with-the-original is wanted.
+
+## Update
+
+```go
+func (*Xxx) Update(
+    ctx context.Context,
+    req infer.UpdateRequest[XxxArgs, XxxState],
+) (infer.UpdateResponse[XxxState], error) {
+    cfg := infer.GetConfig[Config](ctx)
+
+    if req.DryRun {
+        return infer.UpdateResponse[XxxState]{
+            Output: stateFromArgs(req.Inputs),
+        }, nil
+    }
+
+    // Build a partial PATCH body — only the changed fields.
+    patch := map[string]any{}
+    if req.Inputs.Title != req.State.Title {
+        patch["title"] = req.Inputs.Title
+    }
+    // ... one block per field
+    if len(patch) == 0 {
+        return infer.UpdateResponse[XxxState]{Output: req.State}, nil
+    }
+
+    body, err := json.Marshal(patch)
+    if err != nil {
+        return infer.UpdateResponse[XxxState]{}, fmt.Errorf("marshal patch body: %w", err)
+    }
+
+    url := cfg.ServerUrl + "/<resource-path>/" + req.ID
+    res, err := doWithRetry(ctx, cfg.client, http.MethodPatch, url, body, 3)
+    if err != nil {
+        return infer.UpdateResponse[XxxState]{}, err
+    }
+    if res.StatusCode < 200 || res.StatusCode >= 300 {
+        return infer.UpdateResponse[XxxState]{}, errorFromResponse("PATCH", url, res)
+    }
+    defer res.Body.Close()
+
+    var updated <serverObjectType>
+    if err := json.NewDecoder(res.Body).Decode(&updated); err != nil {
+        return infer.UpdateResponse[XxxState]{}, fmt.Errorf("decode PATCH response: %w", err)
+    }
+
+    return infer.UpdateResponse[XxxState]{
+        Output: stateFromServerObject(updated),
+    }, nil
+}
+```
+
+### Patch body shape: alternatives to `map[string]any`
+
+`map[string]any` is the most direct port of TS's partial-object pattern.
+Two alternatives:
+
+**Pointer-struct + `omitempty`:**
+
+```go
+type xxxPatch struct {
+    Title     *string   `json:"title,omitempty"`
+    Completed *bool     `json:"completed,omitempty"`
+    Priority  *Priority `json:"priority,omitempty"`
+}
+patch := xxxPatch{}
+if req.Inputs.Title != req.State.Title {
+    t := req.Inputs.Title
+    patch.Title = &t
+}
+if req.Inputs.Completed != req.State.Completed {
+    c := req.Inputs.Completed
+    patch.Completed = &c
+}
+```
+
+More type-safe, more idiomatic Go, slightly more code. The pointer
+wrappers are not stylistic — they're load-bearing. `omitempty` on a
+plain `bool` cannot distinguish "user wants false" from "field absent":
+both are the zero value, so `json.Marshal` drops them. The same trap
+applies to `int 0`, `float64 0.0`, and `""` for string fields whose
+zero value is a legitimate user-settable input. Wrapping in a pointer
+makes the absence/presence distinction explicit and JSON-correct.
+
+If your resource is string-fields-only and none of them have a
+meaningful empty-string state, plain `omitempty` on non-pointer fields
+also works; that's the degenerate case. Most real resources have at
+least one boolean or numeric field, and pointer-struct is the safe
+default.
+
+**Always-full body:** if the upstream API treats PATCH as full-replacement
+(some APIs do — verify empirically), send the full input body. Simpler but
+loses the "only-changed-fields" discipline; can have side effects on real
+APIs (audit log entries, webhooks firing on unchanged fields).
+
+## Compile-time interface assertions
+
+Add these near the top of the resource file:
+
+```go
+var (
+    _ infer.CustomCheck[XxxArgs]            = (*Xxx)(nil)
+    _ infer.CustomDiff[XxxArgs, XxxState]   = (*Xxx)(nil)
+    _ infer.CustomRead[XxxArgs, XxxState]   = (*Xxx)(nil)
+    _ infer.CustomUpdate[XxxArgs, XxxState] = (*Xxx)(nil)
+    _ infer.CustomDelete[XxxState]          = (*Xxx)(nil)
+)
+```
+
+If a method signature drifts (wrong type parameters, wrong receiver), the
+package fails to compile and the assertion line points to which method is
+broken.

--- a/authoring/skills/pulumi-dynamic-to-go-provider/references/translation-table.md
+++ b/authoring/skills/pulumi-dynamic-to-go-provider/references/translation-table.md
@@ -1,0 +1,113 @@
+# Translation table: TS dynamic provider → `pulumi-go-provider` (`infer`)
+
+Concept-by-concept mapping. Each row is a concept that exists on both sides;
+the friction column flags whether the translation is mechanical or has
+subtleties.
+
+## Authoring model
+
+| Concept | TS dynamic | Go `infer` | Friction |
+|---|---|---|---|
+| Provider model | Class implementing `dynamic.ResourceProvider`, serialised into program state | Long-lived gRPC binary the engine talks to | None — fundamentally different runtime, but the work moves cleanly |
+| Distribution | None — code lives in the program | `pulumi-resource-<name>` binary, found via `Pulumi.yaml` `plugins:` block or `PULUMI_DEBUG_PROVIDERS` | New step; the binary is large (~50 MB with full gRPC + sdk stack) |
+| Resource type definition | Class extending `pulumi.dynamic.Resource` with constructor | Go type with method receivers; typically `type Xxx struct{}` | None — empty struct works fine when no per-instance state needed |
+| Provider class | The dynamic provider class itself | None — the framework runs the resource's methods directly. Configuration lives on a separate `Config` type registered with `infer.Config` | The "provider class" concept disappears as a distinct entity |
+
+## Types
+
+| Concept | TS | Go | Friction |
+|---|---|---|---|
+| Inputs interface | `interface XxxArgs { title: pulumi.Input<string>; ... }` | `type XxxArgs struct { Title string \`pulumi:"title"\` ... }` | Mechanical; `pulumi.Input<T>` becomes plain `T` (the framework resolves before calling) |
+| State shape | Properties on the resource class, populated from `outs` | `type XxxState struct { ... }`, returned from CRUD via response wrappers | Mechanical *except* for `id` — see id row |
+| `id` field | Conventionally in `outs.id`; surfaced as `.id` on the resource | **Reserved** — must NOT appear in state struct. Engine manages it via `CreateResponse.ID` and `req.ID` | **Real friction** — caught at schema-gen with `"id" is a reserved field name`. Remove `Id` from your state struct |
+| Optional fields | `field?: T` or `field: T \| undefined` | `field *T \`pulumi:"field,optional"\`` (pointer + `,optional` tag) | Mechanical |
+| Union types | `"low" \| "medium" \| "high"` | `type Priority string` + constants + `Values()` method (any type with that method becomes a schema enum) | **Cleaner in Go** — schema validates; generated SDK gets union type for free |
+| Nested objects | `{ inner: { x: string } }` | Nested struct with `pulumi:"name"` tag | Mechanical |
+| Lists | `string[]`, `pulumi.Input<string[]>` | `[]string` | Mechanical |
+| Maps | `Record<string, T>` | `map[string]T` | Mechanical |
+
+## CRUD method signatures
+
+All methods take `(ctx context.Context, req XRequest[Args, State])` and return
+`(XResponse[Args, State], error)` in `infer` v1.x.
+
+| Method | TS dynamic | Go `infer` | Notes |
+|---|---|---|---|
+| `check` | `check(olds, news): { inputs?, failures? }` | `Check(ctx, req CheckRequest) (CheckResponse[Args], error)` | Use `infer.DefaultCheck[Args]` to start; add custom failures from there |
+| `diff` | `diff(id, oldOuts, newInputs): { changes?, replaces? }` | `Diff(ctx, req DiffRequest[Args, State]) (DiffResponse, error)` | Go's `DiffResponse` has `HasChanges + DetailedDiff: map[string]PropertyDiff` — richer than TS's binary `changes` |
+| `create` | `create(inputs): { id, outs }` | `Create(ctx, req CreateRequest[Args]) (CreateResponse[State], error)` | Go's `CreateResponse{ID, Output}` — ID is separate from state |
+| `read` | `read(id, props): { id?, props? }` | `Read(ctx, req ReadRequest[Args, State]) (ReadResponse[Args, State], error)` | Empty `ReadResponse{}` signals "gone" (mirrors TS `{}` convention) |
+| `update` | `update(id, oldOuts, newInputs): { outs }` | `Update(ctx, req UpdateRequest[Args, State]) (UpdateResponse[State], error)` | Mechanical |
+| `delete` | `delete(id, props): void` | `Delete(ctx, req DeleteRequest[State]) (DeleteResponse, error)` | Return `infer.DeleteResponse{}` even on success |
+
+## Configuration
+
+| Concept | TS | Go | Friction |
+|---|---|---|---|
+| Source | `pulumi.Config` in program | `pulumi.Config` in consumer; provider receives via `Configure(ctx)` | Mechanical |
+| Wiring | Closure-capture into provider class; baked into resource state per resource | `Config` struct registered with `infer.Config(&Config{})`; retrieved via `infer.GetConfig[Config](ctx)` from each method | **Cleaner in Go** — provider-level config; trap "config baked into state" cannot recur |
+| Setup hook | None | `Configure(ctx) error` method on Config type — called once before any CRUD | **New capability** — natural place to initialise an `*http.Client` |
+| Sharing | Each CRUD method had its own captured copy | One Config struct shared across all methods (long-lived binary); fields on it are concurrent-shared | **New concern** — mutable state on Config must be goroutine-safe (`*http.Client` is fine; a non-thread-safe cache wouldn't be) |
+
+## Concurrency
+
+| Concept | TS | Go |
+|---|---|---|
+| Concurrent CRUD calls | Engine spawns separate child processes; nothing shared | Same binary, multiple goroutines; CRUD calls can run in parallel |
+| Cancellation | None — async functions run to completion | `context.Context` flows through every method; cancellation propagates |
+| Connection reuse | None — each call creates a fresh `fetch` | Long-lived `*http.Client` on Config; `http.Transport` pools connections |
+
+## Error handling
+
+| Concept | TS | Go |
+|---|---|---|
+| Surfacing | `throw new Error(message)` | Return `error`; engine surfaces via `err.Error()` |
+| Wrapping | Stack traces (free) | `fmt.Errorf("...: %w", err)` for wrapping; no stack unless using `pkg/errors` |
+| Body-in-message | `throw new Error(...await res.text()...)` | `defer res.Body.Close()` discipline; read body once via `io.ReadAll` |
+| HTTP error helper | `errorFromResponse(method, url, res)` returning `Error` | Same shape; takes `*http.Response`, closes body internally |
+
+## Retry
+
+| Concept | TS | Go |
+|---|---|---|
+| Library | None — hand-rolled | None — hand-rolled |
+| Time delay | `setTimeout(resolve, ms)` | `select { case <-time.After(d): case <-ctx.Done(): }` |
+| Body lifecycle per attempt | None — fetch's body recreated implicitly | `bytes.NewReader(body)` per attempt (reader is single-use) |
+| Idempotency | Caller decides which methods retry | Same — POST bypasses retry helper; PATCH/GET/DELETE use it |
+
+## Lifecycle
+
+| Concept | TS | Go |
+|---|---|---|
+| `pulumi preview` | Engine doesn't call CRUD methods | `req.DryRun bool` is `true`; methods must short-circuit (return inputs-as-state without HTTP) |
+| Provider startup | None — class instantiated on each call | `Configure(ctx)` called once; init HTTP client here |
+| Provider shutdown | None | Engine signals shutdown; `provider.Run()` returns. Premature exit produces a warning |
+
+## Schema
+
+| Concept | TS | Go |
+|---|---|---|
+| Existence | None | Generated by `infer` from struct tags + `Annotated.Annotate` methods |
+| Property descriptions | None | `a.Describe(&s.Field, "...")` in `Annotate` |
+| Defaults | None | `a.SetDefault(&s.Field, defaultVal, "ENV_VAR")` |
+| Multi-language SDKs | None | `pulumi package gen-sdk` reads schema, emits SDK |
+
+## Resource type token in state
+
+| TS | Go |
+|---|---|
+| `pulumi-nodejs:dynamic:Resource` (generic) | `<provider-name>:index:<ResourceTypeName>` (specific) |
+
+## What you gain in the port
+
+- Schema → multi-language consumers, generated docs, SDK type narrowing.
+- First-class enum, type token, id management.
+- Provider-level config; cancellation; connection pooling.
+
+## What costs more in the port
+
+- Binary build/distribute step.
+- Body-lifecycle ceremony (`defer Close`, body-reader-per-attempt).
+- No `Partial<T>` equivalent for partial PATCH bodies — use `map[string]any`
+  or pointer struct with `omitempty`.
+- Provider lifecycle and shutdown coordination.

--- a/authoring/skills/pulumi-dynamic-to-go-provider/references/traps.md
+++ b/authoring/skills/pulumi-dynamic-to-go-provider/references/traps.md
@@ -1,0 +1,374 @@
+# Known traps when porting TS dynamic → `pulumi-go-provider`
+
+Each entry: **symptom** (what you see) → **cause** → **fix**.
+
+## Schema generation
+
+### `failed to get schema for '<token>': "id" is a reserved field name`
+
+**Symptom**: `pulumi package get-schema ./pulumi-resource-<name>` fails with
+this error (or a similar wording mentioning `id`).
+
+**Cause**: You declared an `Id` field on your State struct (port-1:1 from
+the TS `outs.id`). The Go framework reserves `id` as a property name —
+it manages it itself via `CreateResponse.ID` and `req.ID`.
+
+**Fix**: Remove the `Id` field from the State struct. State is purely the
+non-id properties.
+
+```go
+// Wrong:
+type XxxState struct {
+    Title string `pulumi:"title"`
+    Id    string `pulumi:"id"`  // ← reserved
+}
+
+// Right:
+type XxxState struct {
+    Title string `pulumi:"title"`
+}
+```
+
+Update Create/Read/Update accordingly:
+
+- `CreateResponse{ID: created.Id, Output: stateFromServerObject(created)}`
+- `ReadResponse{ID: req.ID, Inputs: ..., State: stateFromServerObject(current)}`
+- `UpdateResponse{Output: stateFromServerObject(updated)}`
+
+The server's response struct (the `<serverObjectType>` — what comes back
+over the wire) *does* still have an `Id` field with `json:"id"`; that's
+fine. The reservation only applies to types tagged with `pulumi:` for
+schema inclusion.
+
+## Runtime behaviour
+
+### `provider exited prematurely` warning at end of `pulumi destroy`
+
+**Symptom**: All resources destroyed correctly (state empty, server clean),
+but Pulumi prints:
+
+```text
+error: Detected that <path>/pulumi-resource-<name> exited prematurely.
+This is *always* a bug in the provider. Please report the issue to the
+provider author as appropriate.
+```
+
+**Cause**: Framework shutdown handshake quirk — the binary exits before
+the engine's final close completes. Operations completed correctly first;
+the warning is post-hoc.
+
+**Fix**: Currently no clean fix at the user code level — the binary's
+`provider.Run(ctx, ...)` returns when the framework signals shutdown, and
+exits via `os.Exit(0)`. If the warning bothers you, file an issue
+upstream. For the porting exercise, document and ignore.
+
+### Server state contains a `__provider` JSON blob
+
+**Symptom**: GET-ing a resource from the upstream API shows a giant
+`__provider: "..."` field containing serialised JS code.
+
+**Cause**: This is a stage-1 (TS dynamic) trap — `JSON.stringify(inputs)`
+in `create` leaked Pulumi's framework-injected `__provider` field to the
+server. **Cannot recur in Go** because the Go framework has no closure to
+serialise; there's no `__provider` field at all.
+
+**Fix**: If you're seeing this, you're still running the TS provider, not
+the Go one. Confirm with `pulumi stack` that the resources are typed
+`<provider>:index:<Resource>` (Go) not `pulumi-nodejs:dynamic:Resource`
+(TS).
+
+## Build
+
+### `<dep> is not used in this module (go mod tidy)`
+
+**Symptom**: After `go get`, lots of diagnostics about unused transitive
+dependencies.
+
+**Cause**: `go get` eagerly lists transitive deps as direct until you
+import the package. Cosmetic; doesn't affect compilation.
+
+**Fix**: `go mod tidy`. Cleans up the go.mod direct/indirect classification.
+
+### `<dep> should be direct (go mod tidy)`
+
+**Symptom**: After writing your imports and running `go build`, two deps
+are flagged as "should be direct."
+
+**Cause**: Same — `pulumi-go-provider` and `pulumi/sdk/v3` were
+classified as indirect during `go get`; once you import them they should
+be direct.
+
+**Fix**: `go mod tidy`.
+
+### Stray binary named after the Go module path
+
+**Symptom**: After `go build ./...`, you see a binary like `todo-go-provider`
+or `myorg-myproject` instead of `pulumi-resource-<name>`.
+
+**Cause**: `go build ./...` defaults to using the module name for the binary.
+The Pulumi framework expects `pulumi-resource-<name>`.
+
+**Fix**: Build with `-o`:
+
+```bash
+go build -o pulumi-resource-<name> .
+```
+
+Add the stray name to `.gitignore` or `rm` it. The proper binary name is
+how the engine looks up the plugin via `Pulumi.yaml`'s `plugins:` block.
+
+## Retry helper
+
+### Tests/runtime hang on retry helper's last attempt
+
+**Symptom**: A request that should fail-and-retry instead hangs.
+
+**Cause**: Almost always a body-lifecycle issue. The retry helper closes
+`res.Body` on retried attempts but the *final* attempt must NOT close the
+body — the caller needs to read it for the error message via
+`errorFromResponse`.
+
+**Fix**: Inspect the retry loop. The pattern is:
+
+```go
+for attempt := 0; attempt < maxAttempts; attempt++ {
+    res, err := client.Do(req)
+    // ...
+    if isRetryable && attempt < maxAttempts-1 {
+        res.Body.Close()  // close for retry
+        // wait + continue
+        continue
+    }
+    return res, nil  // last attempt or non-retryable: return body open
+}
+```
+
+`errorFromResponse(method, url, res)` then closes via `defer res.Body.Close()`.
+
+### `bytes.NewReader` re-used across retries
+
+**Symptom**: First retry attempt sends an empty body.
+
+**Cause**: `*http.Request.Body` is an `io.Reader`, consumed on first read.
+Reusing the same reader across retries means subsequent attempts read from
+empty.
+
+**Fix**: Construct a fresh `bytes.NewReader(body)` per attempt:
+
+```go
+for attempt := 0; attempt < maxAttempts; attempt++ {
+    var bodyReader io.Reader
+    if body != nil {
+        bodyReader = bytes.NewReader(body)  // fresh per attempt
+    }
+    req, _ := http.NewRequestWithContext(ctx, method, url, bodyReader)
+    // ...
+}
+```
+
+## Update
+
+### PATCH "succeeded" but other fields got nuked
+
+**Symptom**: After running `pulumi up` to update one field, the server's
+copy of the resource has only the field you changed — other fields are
+gone.
+
+**Cause**: You used PUT instead of PATCH (PUT is full replace; partial PUT
+nukes omitted fields), OR the upstream API treats PATCH as full replace.
+
+**Fix**:
+
+- Confirm your method is `http.MethodPatch`, not `http.MethodPut`.
+- Empirically verify the upstream's PATCH semantics: send a partial PATCH
+  with curl, GET the result, see if untouched fields survive.
+- If the API only supports full PUT, you must build a full body in
+  `update` (regress to the pattern stage 1 called "U1") — accept the
+  side-effect risk on real APIs.
+
+### Empty PATCH body sent
+
+**Symptom**: PATCH was called with no changes — empty `{}` body. Server
+may error (some 400 on empty body).
+
+**Cause**: Update was called even though nothing changed; defensive guard
+missing.
+
+**Fix**: Add the no-op short-circuit:
+
+```go
+if len(patch) == 0 {
+    return infer.UpdateResponse[XxxState]{Output: req.State}, nil
+}
+```
+
+(Should not happen if Diff is correct, but defensive guards are cheap.)
+
+## Schema / SDK consumption
+
+### Generated TS SDK can't be imported from consumer
+
+**Symptom**: `import { Xxx } from "@<provider>/<name>"` resolves to
+nothing; TypeScript can't find the module.
+
+**Cause**: The generated SDK isn't built — `npm install` and
+`npm run build` haven't been run inside `sdk/nodejs/`. Or the consumer's
+`package.json` `file:` link points at the wrong path.
+
+**Fix**:
+
+```bash
+cd sdk/nodejs && npm install && npm run build
+cd ../../examples/typescript && npm install
+```
+
+Confirm `package.json` has:
+
+```json
+"@<provider>/<name>": "file:../../sdk/nodejs"
+```
+
+(Path is relative to the consumer's `package.json`.)
+
+### `pulumi config set <key>` rejected — wrong namespace
+
+**Symptom**:
+
+```text
+Configuration key '<provider>:<key>' is not namespaced by the project
+and should not define a type.
+```
+
+**Cause**: You declared a `config:` block in the consumer's `Pulumi.yaml`
+with a provider-namespaced key (`<provider>:<key>`). Project-level config
+declaration is for *project-namespaced* keys only; provider config doesn't
+need declaration.
+
+**Fix**: Remove the offending entry from `Pulumi.yaml`'s `config:` block.
+For provider config, just `pulumi config set <provider>:<key> <value>`
+without declaration.
+
+### Missing required config var `<consumer-name>:<key>` on `pulumi up`
+
+**Symptom**: First `pulumi up` after setting provider config fails with:
+
+```text
+error: Missing required configuration variable '<consumer-name>:<key>'
+       please set a value using the command
+       `pulumi config set <consumer-name>:<key> <value>`
+```
+
+— even though you ran `pulumi config set <provider-name>:<key> <value>`.
+
+**Cause**: The consumer's `index.ts` mirrors stage 1's pattern, reading
+project-namespaced config and forwarding it explicitly:
+
+```ts
+const cfg = new pulumi.Config();
+const url = cfg.require("serverUrl");           // project-namespaced
+const provider = new xxx.Provider("xxx", { serverUrl: url });
+```
+
+`cfg.require("serverUrl")` reads `<consumer-name>:serverUrl`, *not*
+`<provider-name>:serverUrl`. Setting only the provider-namespaced key
+leaves the project-namespaced read unsatisfied.
+
+**Fix** — three options, in increasing order of "how much the consumer
+diverges from stage 1":
+
+1. **Set both** — most faithful to the stage-1 mental model:
+
+   ```bash
+   pulumi config set serverUrl <value>                  # project-namespaced
+   pulumi config set <provider-name>:serverUrl <value>  # provider-namespaced
+   ```
+
+2. **Drop the project read in the consumer**, set provider config only:
+
+   ```ts
+   // index.ts: remove the pulumi.Config() line
+   const provider = new xxx.Provider("xxx", {});
+   ```
+
+   Requires the SDK's `ProviderArgs.serverUrl` to be schema-optional
+   (`pulumi:"serverUrl,optional"` on the Go side) so the value can come
+   from provider config alone. Most providers want the field required,
+   so this fix usually doesn't apply cleanly.
+
+3. **Remove the explicit Provider construction**, use the default
+   provider via provider-namespaced config:
+
+   ```ts
+   // No `new xxx.Provider(...)` at all.
+   const r = new xxx.Resource("name", { ... });  // engine picks default provider
+   ```
+
+   ```bash
+   pulumi config set <provider-name>:serverUrl <value>
+   ```
+
+   Cleanest going forward, but loses the "construct one provider, share
+   it across resources" pattern stage 1 used.
+
+Option 1 is the lowest-friction port of stage 1; choose it unless you
+have a reason to restructure.
+
+## Backend / login
+
+### Don't run `pulumi login --local` without checking `whoami` first
+
+**Symptom**: User reports they were logged into the cloud backend; the
+agent ran `pulumi login --local` to "fix" a perceived auth issue; now
+their cloud stacks aren't accessible until they `pulumi login` again.
+
+**Cause**: `pulumi login --local` switches the active backend to the
+file-backed local backend. It doesn't *delete* the cloud session, but
+it deactivates it for the current shell until the user re-runs
+`pulumi login`. Running it eagerly disrupts user state for no reason —
+the verification flow doesn't care which backend is active.
+
+**Fix**: Always `pulumi whoami` before any backend-touching command
+(`stack init`, `up`, `config set`, etc.):
+
+```bash
+pulumi whoami
+```
+
+If it succeeds, the user is already logged in to *some* backend; that's
+all the skill needs. Proceed.
+
+If it fails (`error: getting backend: ... not logged in`), ask the user
+which backend rather than choosing for them:
+
+- `pulumi login` — cloud backend (their pulumi.com account)
+- `pulumi login --local` — file-backed local-only backend
+- `pulumi login s3://...`, `pulumi login azblob://...`, etc. — other
+  supported self-hosted backends
+
+The verification flow works identically across all of them.
+
+## Method signatures
+
+### Method exists but framework doesn't see it
+
+**Symptom**: Custom `Diff`/`Check`/`Update` is written but the engine
+doesn't call it (default behaviour kicks in instead).
+
+**Cause**: Method signature drifted out of conformance with the framework
+interface (wrong type parameter, pointer vs value receiver, wrong request
+type).
+
+**Fix**: Add compile-time interface assertions early so signature drift
+fails at build:
+
+```go
+var (
+    _ infer.CustomCheck[XxxArgs]            = (*Xxx)(nil)
+    _ infer.CustomDiff[XxxArgs, XxxState]   = (*Xxx)(nil)
+    _ infer.CustomRead[XxxArgs, XxxState]   = (*Xxx)(nil)
+    _ infer.CustomUpdate[XxxArgs, XxxState] = (*Xxx)(nil)
+    _ infer.CustomDelete[XxxState]          = (*Xxx)(nil)
+)
+```
+
+If any of these fails, the assertion line points at the broken method.

--- a/authoring/skills/pulumi-dynamic-to-go-provider/references/verification-flow.md
+++ b/authoring/skills/pulumi-dynamic-to-go-provider/references/verification-flow.md
@@ -1,0 +1,150 @@
+# End-to-end verification flow
+
+The same lifecycle the source TS provider ran, applied to the new Go
+provider. Every CRUD method gets exercised. Run this in the consumer
+directory (`go-provider/examples/typescript/`).
+
+## Prerequisites
+
+- `pulumi-resource-<name>` binary built in `go-provider/`
+- `sdk/nodejs/` generated and built (`npm run build`)
+- `examples/typescript/` set up with `package.json` linked to the SDK
+- The upstream API (json-server, real cloud API, etc.) reachable
+- A Pulumi stack initialised with appropriate config
+
+## Script (run from `examples/typescript/`)
+
+### 1. Create
+
+```bash
+pulumi up --yes
+```
+
+**Expected**: All declared resources created. Stack outputs surface
+server-assigned IDs.
+
+**Exercises**: `Check`, `Create`, `Diff` (all-new diff is straightforward).
+
+**Verify on the server side**: GET the resource you just created and
+confirm only the user-supplied fields are present. The Go framework
+cannot serialise a closure into the request body — there is structurally
+no equivalent of stage-1's `__provider` leak — but inspecting the server
+state proves it, and surfaces any other sidecar fields the framework or
+upstream API might have introduced. For json-server:
+
+```bash
+curl -s http://localhost:3000/<resource-path> | python3 -m json.tool
+```
+
+Confirm: only the input fields plus the server-assigned id appear. No
+provider source, no closure-captured config, no framework metadata.
+
+This step turns the structural safety claim ("can't recur in Go") into
+an empirical observation, and is the most direct way to demonstrate why
+the port is worth doing if the source provider had a leak history.
+
+### 2. Update
+
+Modify *one* field of *one* resource in `index.ts`. Example: flip a
+`completed: false` to `completed: true`.
+
+```bash
+pulumi up --yes
+```
+
+**Expected**: Output annotation `[diff: ~<field-name>]` showing exactly
+which field changed.
+
+**Exercises**: `Check`, `Diff`, `Update`.
+
+**Verify**: GET the modified resource. Confirm the changed field has the
+new value AND other fields are preserved (i.e., `Update` sent a partial
+PATCH, not a full PUT that nuked everything).
+
+```bash
+curl -s http://localhost:3000/<resource-path>/<id> | python3 -m json.tool
+```
+
+### 3. Refresh (drift detection)
+
+Drift the server-side state out-of-band. Example for json-server:
+
+```bash
+curl -s -X PATCH http://localhost:3000/<resource-path>/<id> \
+  -H 'Content-Type: application/json' \
+  -d '{"<field>":"out-of-band drift"}'
+```
+
+```bash
+pulumi refresh --yes
+```
+
+**Expected**: One resource shown as "updated" (the one you drifted),
+others unchanged.
+
+**Exercises**: `Read`. The drift gets pulled into Pulumi state.
+
+A subsequent `pulumi up` should now show a diff (drifted state vs
+declared inputs) and reconcile back. If you want to confirm:
+
+```bash
+pulumi up --yes
+```
+
+You should see the same `[diff: ~<field>]` annotation as in step 2,
+running update to put the value back to what `index.ts` declares.
+
+### 4. Idempotent destroy
+
+Manually delete one resource on the server before destroy:
+
+```bash
+curl -s -X DELETE http://localhost:3000/<resource-path>/<id>
+```
+
+```bash
+pulumi destroy --yes
+```
+
+**Expected**:
+
+- All resources reported as deleted (count matches what was created).
+- For the pre-deleted one: a warning log line containing `"already
+  deleted on server"` (or similar from your `Delete` method's log
+  statement).
+
+**Exercises**: `Delete`'s 404-as-success path (idempotent destroy).
+
+**Verify**:
+
+```bash
+curl -s http://localhost:3000/<resource-path>
+# expect: []
+pulumi stack
+# expect: "No resources currently in this stack"
+```
+
+## What success looks like
+
+All four steps above complete without errors (the "provider exited
+prematurely" warning at the tail of step 4 is benign — see traps.md).
+
+If any step fails, the failure is almost certainly one of the entries in
+[traps.md](./traps.md). Match the symptom and apply the fix.
+
+## What to compare against the source
+
+If both the original TS and the new Go provider can be run side by side
+(see [SKILL.md](../SKILL.md) step 1's note about preserving the source as
+a comparison artefact), run the same lifecycle against both. Differences
+worth noting in the porting log:
+
+- **Resource type token**: `pulumi-nodejs:dynamic:Resource` (TS) vs
+  `<provider>:index:<Resource>` (Go).
+- **State shape**: TS state has `id` in `outs`; Go state does not (`id`
+  is engine-managed).
+- **Server-side data shape**: TS may have `__provider` blob; Go won't.
+- **Per-operation timing**: roughly the same; Go may have one-time
+  provider startup overhead on the first call.
+- **Error messages**: should look identical in shape (method, URL,
+  status, body).

--- a/authoring/skills/pulumi-dynamic-to-go-provider/use_cases.yaml
+++ b/authoring/skills/pulumi-dynamic-to-go-provider/use_cases.yaml
@@ -1,0 +1,25 @@
+# Queries that should activate the pulumi-dynamic-to-go-provider skill
+queries:
+  # Direct port / convert requests
+  - "Convert this TypeScript dynamic provider to a Go provider"
+  - "Port my pulumi.dynamic.ResourceProvider implementation to pulumi-go-provider"
+  - "Migrate from pulumi.dynamic.Resource to infer.Provider"
+  - "Turn this TS dynamic provider into a Go provider with a generated SDK"
+  - "I want to rewrite my dynamic provider in Go using pulumi-go-provider"
+
+  # Distribution / SDK questions implying the port
+  - "How do I make my dynamic provider into a real distributable provider?"
+  - "How do I generate multi-language SDKs from a dynamic provider?"
+  - "My dynamic provider works in TS but I need to publish it for other languages"
+  - "Convert my pulumi.dynamic provider so it can be consumed from Python and Go"
+
+  # Specific subtasks of the port
+  - "How do I translate a TypeScript dynamic provider's check/diff/create/read/update/delete to Go?"
+  - "What's the equivalent of pulumi.dynamic.ResourceProvider in pulumi-go-provider?"
+  - "How do I port a fetchWithRetry helper from a TS dynamic provider to Go?"
+  - "Why does pulumi package get-schema say `id` is a reserved field name in my Go provider?"
+  - "How should I structure the partial PATCH body when porting a dynamic provider's update method to Go?"
+
+  # Workflow / process
+  - "Walk me through migrating a TypeScript pulumi.dynamic provider to a Go infer-based provider"
+  - "What's the safe sequence for porting a dynamic provider to pulumi-go-provider end-to-end?"


### PR DESCRIPTION
## Summary

- Adds a new authoring skill that walks users through porting a working TypeScript `pulumi.dynamic.ResourceProvider` to a distributable `pulumi-go-provider` binary built on the `infer` package.
- Covers the parts of the port that are not mechanical: the six CRUD method mappings (check/diff/create/read/update/delete), retry-helper translation, schema generation via `pulumi package gen-sdk`, and the consumer-side wiring needed to exercise the generated SDK end-to-end.
- Surfaces the traps that only show up during schema generation or full lifecycle runs (reserved field names, partial PATCH bodies, drift refresh behavior) so authors hit them once, not iteratively.

## Test plan

- [x] `use_cases.yaml` provided with representative trigger queries for the routing accuracy test
- [x] `uv run pytest tests/test_manifests.py` passes (no manifest changes required — plugin auto-discovers the skill directory)
- [ ] `uv run pytest tests/test_skill_selection_accuracy.py` (requires `ANTHROPIC_API_KEY`; runs in CI)
- [ ] `uv run pytest tests/test_skill_quality.py` (requires `ANTHROPIC_API_KEY`; runs in CI)
- [x] `markdownlint` passes on changed markdown files

## Changes

### New files

- `authoring/skills/pulumi-dynamic-to-go-provider/SKILL.md` — main skill with workflow, CRUD translation guidance, and verification flow
- `authoring/skills/pulumi-dynamic-to-go-provider/use_cases.yaml` — trigger queries for the skill routing accuracy test
- `authoring/skills/pulumi-dynamic-to-go-provider/references/` — progressive-disclosure references: `crud-patterns.md`, `translation-table.md`, `traps.md`, `verification-flow.md`
- `authoring/skills/pulumi-dynamic-to-go-provider/assets/` — copy-paste scaffolding: `scaffold-main.go`, `http_retry.go`, `consumer-Pulumi.yaml`, `consumer-package.json`

### Modified files

- `AGENTS.md` — list the new skill under the authoring plugin
- `README.md` — add the skill to the authoring skills table