### PR TITLE
Add pulumi-neo-handoff skill in new delegation plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -26,6 +26,17 @@
         "installation": "AVAILABLE"
       },
       "category": "Coding"
+    },
+    {
+      "name": "pulumi-delegation",
+      "source": {
+        "source": "local",
+        "path": "./delegation"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Coding"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,6 +19,12 @@
       "source": "./authoring",
       "description": "Write quality Pulumi programs, components, and automation",
       "category": "development"
+    },
+    {
+      "name": "pulumi-delegation",
+      "source": "./delegation",
+      "description": "Hand off in-progress work from coding agents to Pulumi Neo",
+      "category": "integration"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@ Skills for writing quality Pulumi programs, components, automation, and secrets 
 - **pulumi-upgrade-provider**: Automate Pulumi provider repo upgrades with the upgrade-provider tool
 - **upstream-patches**: Create, amend, remove, and rebase patches for Terraform provider submodules
 
+### Delegation Plugin (`delegation/`)
+
+Skills for handing off in-progress work from coding agents to Pulumi Neo for delegated execution:
+
+- **pulumi-neo-handoff**: Transfer the current work to a new Pulumi Neo task with goal, repository pointers, and a compacted conversation summary
+
 ## Installation
 
 ### Claude Code Plugin System
@@ -35,6 +41,7 @@ Skills for writing quality Pulumi programs, components, automation, and secrets 
 /plugin marketplace add pulumi/agent-skills
 /plugin install pulumi-migration
 /plugin install pulumi-authoring
+/plugin install pulumi-delegation
 ```
 
 ### OpenAI Codex
@@ -43,7 +50,7 @@ Skills for writing quality Pulumi programs, components, automation, and secrets 
 codex plugin marketplace add pulumi/agent-skills
 ```
 
-After the marketplace registers, install plugins from the Codex TUI: run `codex`, open the plugin marketplace, and pick `pulumi-migration` or `pulumi-authoring`.
+After the marketplace registers, install plugins from the Codex TUI: run `codex`, open the plugin marketplace, and pick `pulumi-migration`, `pulumi-authoring`, or `pulumi-delegation`.
 
 ### Universal (all agents)
 
@@ -57,7 +64,8 @@ Or install individual plugin groups:
 
 ```bash
 npx skills add pulumi/agent-skills/migration --skill '*'     # 4 migration skills
-npx skills add pulumi/agent-skills/authoring --skill '*'     # 5 authoring skills
+npx skills add pulumi/agent-skills/authoring --skill '*'     # 7 authoring skills
+npx skills add pulumi/agent-skills/delegation --skill '*'    # 1 delegation skill
 ```
 
 This works with Claude Code, Cursor, Copilot, Codex, and other agent tools.
@@ -146,7 +154,7 @@ uv run pytest tests/ -v
 
 ## Adding a New Skill
 
-1. Determine which plugin group the skill belongs to (migration or authoring)
+1. Determine which plugin group the skill belongs to (migration, authoring, or delegation)
 2. Create the skill directory: `<plugin>/skills/<skill-name>/`
 3. Write the `SKILL.md` file with proper frontmatter:
    ```yaml

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Skills are organized into two plugin groups:
 ```
 pulumi-agent-skills/
 ├── migration/          # Convert and import from other tools
-└── authoring/          # Write quality Pulumi programs
+├── authoring/          # Write quality Pulumi programs
+└── delegation/         # Hand off work to Pulumi Neo
 ```
 
 ## Available Skills
@@ -49,6 +50,14 @@ Write quality Pulumi programs, components, automation, and secrets management:
 | [pulumi-upgrade-provider](authoring/skills/pulumi-upgrade-provider) | Automate Pulumi provider repo upgrades |
 | [upstream-patches](authoring/skills/upstream-patches) | Manage upstream Terraform patch stacks in provider repos |
 
+### Delegation Skills
+
+Hand off in-progress work from coding agents to Pulumi Neo:
+
+| Skill | Description |
+|-------|-------------|
+| [pulumi-neo-handoff](delegation/skills/pulumi-neo-handoff) | Transfer the current work to a Pulumi Neo task with goal, repository pointers, and a compacted conversation summary |
+
 ## Installation
 
 ### Claude Code Plugin System
@@ -57,6 +66,7 @@ Write quality Pulumi programs, components, automation, and secrets management:
 /plugin marketplace add pulumi/agent-skills
 /plugin install pulumi-migration     # Install migration skills
 /plugin install pulumi-authoring     # Install authoring skills
+/plugin install pulumi-delegation    # Install delegation skills (Neo handoff)
 ```
 
 ### OpenAI Codex
@@ -65,7 +75,7 @@ Write quality Pulumi programs, components, automation, and secrets management:
 codex plugin marketplace add pulumi/agent-skills
 ```
 
-Once the marketplace is registered, install plugins from the Codex TUI: run `codex`, open the plugin marketplace, and pick `pulumi-migration` or `pulumi-authoring`.
+Once the marketplace is registered, install plugins from the Codex TUI: run `codex`, open the plugin marketplace, and pick `pulumi-migration`, `pulumi-authoring`, or `pulumi-delegation`.
 
 ### Universal (all agents)
 
@@ -79,7 +89,8 @@ Or install individual plugin groups:
 
 ```bash
 npx skills add pulumi/agent-skills/migration --skill '*'     # 4 migration skills
-npx skills add pulumi/agent-skills/authoring --skill '*'     # 5 authoring skills
+npx skills add pulumi/agent-skills/authoring --skill '*'     # 7 authoring skills
+npx skills add pulumi/agent-skills/delegation --skill '*'    # 1 delegation skill
 ```
 
 This works with Claude Code, Cursor, Copilot, Codex, and other agent tools.
@@ -132,6 +143,16 @@ Help me upgrade the Pulumi AWS provider safely without changing real infrastruct
 ```
 
 The assistant will use the `provider-upgrade` skill to guide you through a low-risk upgrade workflow.
+
+### Handing Off Work to Pulumi Neo
+
+Ask your AI assistant:
+
+```text
+Hand this off to Neo to apply the staging migration in production
+```
+
+The assistant will use the `pulumi-neo-handoff` skill to package the goal, repository state, and conversation summary into a new Pulumi Neo task and return a task URL.
 
 ## Contributing
 

--- a/delegation/.claude-plugin/plugin.json
+++ b/delegation/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "pulumi-delegation",
+  "version": "1.0.0",
+  "description": "Hand off in-progress work from coding agents to Pulumi Neo for delegated execution",
+  "author": {
+    "name": "Pulumi",
+    "url": "https://github.com/pulumi"
+  },
+  "homepage": "https://www.pulumi.com/docs/",
+  "repository": "https://github.com/pulumi/agent-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "pulumi",
+    "neo",
+    "agent",
+    "handoff",
+    "delegation",
+    "task-transfer"
+  ]
+}

--- a/delegation/.codex-plugin/plugin.json
+++ b/delegation/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "pulumi-delegation",
+  "version": "1.0.0",
+  "description": "Hand off in-progress work from coding agents to Pulumi Neo for delegated execution",
+  "skills": "./skills/",
+  "author": {
+    "name": "Pulumi",
+    "url": "https://github.com/pulumi"
+  },
+  "homepage": "https://www.pulumi.com/docs/",
+  "repository": "https://github.com/pulumi/agent-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "pulumi",
+    "neo",
+    "agent",
+    "handoff",
+    "delegation",
+    "task-transfer"
+  ],
+  "interface": {
+    "displayName": "Pulumi Delegation",
+    "shortDescription": "Hand off in-progress work from coding agents to Pulumi Neo",
+    "developerName": "Pulumi",
+    "category": "Coding",
+    "websiteURL": "https://www.pulumi.com/docs/",
+    "defaultPrompt": [
+      "Use $pulumi-neo-handoff to package the current conversation and launch a Pulumi Neo task"
+    ]
+  }
+}

--- a/delegation/skills/pulumi-neo-handoff/SKILL.md
+++ b/delegation/skills/pulumi-neo-handoff/SKILL.md
@@ -119,6 +119,8 @@ Invoke the CLI:
 pulumi neo "$(cat "$PROMPT_FILE")"
 ```
 
+`pulumi neo` accepts the prompt as a single positional argument; it has no `--file` flag, and stdin redirection launches the TUI instead of consuming the prompt. The `"$(cat ...)"` form captures the file's bytes as data (the shell does not re-evaluate `$`, backticks, or `\` inside command substitution) and passes them as one argument. Do not "fix" this to `pulumi neo --file ...` or `pulumi neo < ...` — both forms are broken against the current CLI.
+
 If the CLI exits non-zero, surface its stderr verbatim and leave the prompt file in place so the user can retry. Do not pretend the handoff succeeded.
 
 ### 6. Surface the task URL

--- a/delegation/skills/pulumi-neo-handoff/SKILL.md
+++ b/delegation/skills/pulumi-neo-handoff/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: pulumi-neo-handoff
+description: Hand off the current thread to a new Pulumi Neo task as a one-way transfer. Use when the user explicitly asks to hand off, send, transfer, or continue current work in Pulumi Neo (e.g. "hand this to Neo", "continue in Neo", "/neo-handoff"). Do not load when the user only mentions Neo, asks what Neo can do, asks for an AI-written PR or preview explanation, or hands off to a different agent.
+---
+
+# Pulumi Neo Handoff
+
+Transfer the current in-progress work to a new Pulumi Neo task. This is a one-way handoff: control passes to Neo and does not return to the calling agent.
+
+## Calling agent behavior
+
+When this skill activates, act as a handoff coordinator, not the operator:
+
+- Do not narrate the handoff turn-by-turn. The user has decided; carry it out quietly.
+- Do not paste the assembled prompt body into chat. Show only the temp file path so the user can inspect on demand.
+- Do not continue working on the task after launching. Exit cleanly once the task URL is returned.
+
+## What gets transferred
+
+The Neo task receives a single opening prompt with three sections:
+
+1. **Goal** — one sentence describing what Neo should do next.
+2. **Repository pointers** — repo root, branch, working directory, working-tree state, and 3 to 5 files most relevant to the in-progress work.
+3. **Conversation summary** — a compact account of what has been discussed, decided, and left open.
+
+Do not include diffs, full file contents, or tool output. Neo sees the local working tree directly (including uncommitted changes); duplicating that content wastes Neo's opening context.
+
+## Workflow
+
+### 0. Preflight
+
+Verify the CLI is available before drafting anything:
+
+```bash
+command -v pulumi >/dev/null || { echo "pulumi CLI not installed"; exit 1; }
+pulumi neo --help >/dev/null 2>&1 || { echo "pulumi neo unavailable — run 'pulumi login' or upgrade the CLI"; exit 1; }
+```
+
+If preflight fails, surface the error to the user and stop. Do not assemble the prompt only to fail at launch.
+
+### 1. Determine the goal
+
+The goal is one sentence describing what Neo should do next. If the user's handoff message contains it ("hand this off to Neo and apply the staging migration"), use it directly. Otherwise ask once: "What would you like Neo to do next?"
+
+Do not restate the goal back for confirmation — the handoff should feel seamless, and if Neo receives a misread goal the user can redirect inside the Neo task.
+
+### 2. Gather repository context
+
+Capture the canonical repo pointer and branch state:
+
+```bash
+git rev-parse --show-toplevel    # repo root (canonical pointer)
+git rev-parse --abbrev-ref HEAD  # branch; returns "HEAD" if detached
+git status --short               # working-tree summary
+```
+
+If `git rev-parse --show-toplevel` fails the directory is not a git repo — omit the Repository section and note the working directory only. Neo can still operate, but its repo context will be limited.
+
+If the branch reads `HEAD`, record the commit SHA and label the entry "detached at `<sha>`".
+
+Identify 3 to 5 files most relevant to the in-progress work from the conversation (files read, edited, or repeatedly discussed). If the conversation does not clearly identify files, list none rather than guessing — wrong files mislead Neo more than missing files do.
+
+### 3. Draft the conversation summary
+
+Write a compact summary against the structure below. Sections with nothing useful to say should be omitted, not padded.
+
+```
+## What's been done
+<bullets: decisions made, code changed, dead ends ruled out>
+
+## Open questions
+<bullets: things the user has not resolved>
+
+## Next step
+<one or two sentences describing what Neo should do first>
+```
+
+Target ~400 words for the summary. Compress aggressively. The goal is to give Neo enough to pick up cleanly, not to replay the conversation.
+
+### 4. Assemble the prompt and write to a temp file
+
+Combine the three sections into a single markdown document. Use `mktemp` for a portable temp path:
+
+```bash
+PROMPT_FILE="$(mktemp -t neo-handoff.XXXXXX.md)"
+```
+
+Shape:
+
+```markdown
+# Goal
+<one-sentence goal>
+
+# Repository
+- Root: <repo root>
+- Branch: <branch or "detached at <sha>">
+- Working directory: <cwd>
+- Working tree: <clean | dirty>
+- Files in play:
+  - <file 1>
+  - <file 2>
+
+# Conversation summary
+<summary from step 3>
+```
+
+### 5. Launch
+
+Print the temp file path with a one-line size summary so the user can inspect on demand:
+
+```
+Prompt written to <PROMPT_FILE> (<line count> lines, <byte count> bytes).
+Launching Neo task...
+```
+
+Invoke the CLI:
+
+```bash
+pulumi neo "$(cat "$PROMPT_FILE")"
+```
+
+If the CLI exits non-zero, surface its stderr verbatim and leave the prompt file in place so the user can retry. Do not pretend the handoff succeeded.
+
+### 6. Surface the task URL
+
+The CLI prints a task URL on success. Echo it verbatim. Then stop.
+
+## What not to do
+
+- **Do not invoke this skill without explicit handoff intent.** Detecting infrastructure-shaped work is not a trigger; capability questions like "can Neo do X" are not handoffs. Activating on those would make the skill noisy and incorrect.
+- **Do not include diffs, file contents, or command output in the prompt.** Neo sees the local working tree directly, so duplicating that content wastes its opening context.
+- **Do not paste the assembled prompt into chat for confirmation.** Summaries can be long; the file path is sufficient for the user to inspect when they care.
+- **Do not commit, push, or modify the working tree on the user's behalf.** The user owns their git state — the skill is a context handoff, not a workflow controller.
+
+## Notes
+
+- One-way handoff. Control passes to the Neo task and does not return to the calling agent.
+- Neo tasks are interruptible. If the summary turns out to be wrong, the user can redirect inside the Neo task; the skill does not need to guard against summary errors at launch time.
+- Surfacing the task URL is the skill's success criterion, not successful completion of the underlying work. Neo may decline or redirect the request inside the task.

--- a/delegation/skills/pulumi-neo-handoff/agents/openai.yaml
+++ b/delegation/skills/pulumi-neo-handoff/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Pulumi Neo Handoff"
+  short_description: "Hand off the current thread to a new Pulumi Neo task"
+  default_prompt: "Use $pulumi-neo-handoff to package the current conversation and launch a Pulumi Neo task; ask the user for the goal if it is not obvious from context."

--- a/delegation/skills/pulumi-neo-handoff/use_cases.yaml
+++ b/delegation/skills/pulumi-neo-handoff/use_cases.yaml
@@ -1,0 +1,32 @@
+# Queries that should activate the pulumi-neo-handoff skill
+queries:
+  # Explicit handoff requests
+  - "Hand this off to Neo"
+  - "Hand off this Pulumi work to Neo"
+  - "Send this to Pulumi Neo"
+  - "Send the current task to Neo"
+  - "Transfer this work to Pulumi Neo"
+  - "Continue this in Neo"
+  - "Let's hand this off to Neo and continue there"
+  - "Let Neo take this from here"
+  - "Neo can take it from here"
+  - "I want to switch to Neo for the rest of this"
+  - "I'm done here, Neo can take it"
+  - "Take this to Neo"
+  - "Kick this over to Neo"
+
+  # Context-aware phrasings
+  - "Open a Neo task with this context"
+  - "Create a Neo task to continue what we're working on"
+  - "Pulumi Neo can take over from here, package up the context"
+  - "Pass this conversation context to Neo and let it run"
+  - "Ship this context to a Neo task"
+
+  # Product/role-based phrasings
+  - "Send to our Pulumi infra agent"
+  - "Let the Pulumi agent finish this"
+
+  # Slash/command phrasings
+  - "Neo handoff"
+  - "/neo-handoff"
+  - "Run the neo-handoff command on this"


### PR DESCRIPTION
## Summary

Adds a third plugin group, `delegation/`, with a single skill (`pulumi-neo-handoff`) that lets coding agents transfer in-progress work to a new Pulumi Neo task. User-invoked: the skill packages the goal, repository pointers, and a compacted conversation summary, then shells out to `pulumi neo` to launch the task. One-way handoff — control passes to Neo and does not return to the calling agent.

## What's included

- `delegation/skills/pulumi-neo-handoff/SKILL.md` — workflow with preflight, repo context, summary structure, temp-file + CLI invocation, and explicit "calling agent behavior" guardrails (don't narrate, don't paste prompt body, don't return after launch).
- `delegation/skills/pulumi-neo-handoff/use_cases.yaml` — trigger queries spanning explicit handoffs, contextual phrasings, and slash-command forms.
- `delegation/skills/pulumi-neo-handoff/agents/openai.yaml` — Codex display metadata.
- `delegation/.claude-plugin/plugin.json` and `delegation/.codex-plugin/plugin.json` — plugin manifests for both ecosystems.
- Updates to `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`, `AGENTS.md`, and `README.md` registering the new plugin group.

## Design notes

- **One-way semantics** (Microsoft Agent Framework terminology): handoff orchestration, not agent-as-tool. The calling agent stops after launch.
- **Context payload** matches the genre: structured goal, repo pointers, compacted conversation summary. No diffs or tool output — Neo sees the local working tree directly via the CLI, so duplicating that content wastes its opening context.
- **Activation surface** is tuned to fire only on explicit handoff intent. Capability questions ("can Neo do X"), preview/PR-explanation requests, and handoffs to other agents are excluded in the description.
- **Aligns with prior art**: OpenAI Agents SDK `handoff()` primitive (structured payload, one-way), Codex Local↔Worktree handoff (compacted-context pattern), Windsurf 2.0 local→cloud handoff.

## Tests

- `tests/test_manifests.py` passes locally (8/8 — both Claude and Codex plugin manifests validate, both marketplace catalogs reference existing plugin directories).
- LLM-judge tests (`test_skill_selection_accuracy.py`, `test_skill_quality.py`) will run on CI.

Draft for now — pending end-to-end smoke test against a real `pulumi neo` invocation.