### PR TITLE
pulumi-esc: document approval-gated environment workflow

### DIFF
--- a/authoring/skills/pulumi-esc/SKILL.md
+++ b/authoring/skills/pulumi-esc/SKILL.md
@@ -153,10 +153,11 @@ pulumi config  # Verify environment values are accessible
 
 ### Updating approval-gated environments
 
-If `pulumi env edit <env>` or `PATCH /api/esc/environments/...` fails with a
-409 about a change request, the environment requires every update to be
-approved. Use the CLI's `--draft` flag — it bundles create-draft with
-submit-change-request:
+Some environments are **approval-gated** — every update must go through a
+change request before it takes effect. A plain `pulumi env edit <env>` (or
+`PATCH /api/esc/environments/...`) against one fails with an error saying the
+update requires a change request. Use the CLI's `--draft` flag instead — it
+bundles create-draft with submit-change-request:
 
 ```bash
 pulumi env set  --draft <org>/<project>/<env> <key> <value>          # single key

--- a/authoring/skills/pulumi-esc/SKILL.md
+++ b/authoring/skills/pulumi-esc/SKILL.md
@@ -151,6 +151,54 @@ pulumi config env add my-project/dev-config
 pulumi config  # Verify environment values are accessible
 ```
 
+### Updating approval-gated environments
+
+Some environments require every update to be approved via a **change request**
+before it takes effect. Two signals indicate an environment is approval-gated:
+
+- `PATCH /api/esc/environments/{org}/{project}/{env}` returns **409** with the
+  message *"This environment requires updates to be approved via change
+  request. Please use the draft endpoint instead."*
+- `pulumi env edit <env>` (without `--draft`) fails for the same reason.
+
+**Always use the CLI's `--draft` flag for these environments.** The CLI wraps
+draft-create + change-request-submit into a single atomic call and prints
+`Change request submitted`:
+
+```bash
+# Single-key update — recommended for small edits
+pulumi env set --draft <org>/<project>/<env> <key> <value>
+pulumi env set --draft <org>/<project>/<env> <key> <value> --secret
+
+# Full-file replace — recommended when changing structure or many keys
+pulumi env edit --draft --file /tmp/new-env.yaml <org>/<project>/<env>
+```
+
+After the command returns, the change request is visible in the approver's
+queue and the environment is unlocked once the request is closed or applied.
+
+#### What NOT to do
+
+Do **not** call `pulumi cloud api CreateEnvironmentDraft` /
+`UpdateEnvironmentDraft` directly (via `pulumi cloud api` or any raw HTTP
+client). Those endpoints create a draft but **do not** submit a change request,
+leaving an **orphan draft** that is invisible to approvers and that blocks any
+further `--draft` operations on the same environment until it is closed. The
+CLI's `--draft` wrappers above already handle the submit step; use them
+instead.
+
+If you discover an orphan draft (a `GET
+/api/change-requests/{org}/{changeRequestID}` returns status `"draft"` that you
+did not intend to leave open), find and close it:
+
+```bash
+# List open change requests for the env to find the orphan
+pulumi cloud api -X GET "/api/change-requests/<org>?entityType=environment&entityId=<env>"
+
+# Close it (no CLI wrapper exists for this today)
+pulumi cloud api -X POST "/api/change-requests/<org>/<changeRequestID>/close" -d '{}'
+```
+
 ### API Access (Rare)
 
 **Always prefer CLI commands.** Only use the API when absolutely necessary (e.g., bulk operations, automation).

--- a/authoring/skills/pulumi-esc/SKILL.md
+++ b/authoring/skills/pulumi-esc/SKILL.md
@@ -153,49 +153,27 @@ pulumi config  # Verify environment values are accessible
 
 ### Updating approval-gated environments
 
-Some environments require every update to be approved via a **change request**
-before it takes effect. Two signals indicate an environment is approval-gated:
-
-- `PATCH /api/esc/environments/{org}/{project}/{env}` returns **409** with the
-  message *"This environment requires updates to be approved via change
-  request. Please use the draft endpoint instead."*
-- `pulumi env edit <env>` (without `--draft`) fails for the same reason.
-
-**Always use the CLI's `--draft` flag for these environments.** The CLI wraps
-draft-create + change-request-submit into a single atomic call and prints
-`Change request submitted`:
+If `pulumi env edit <env>` or `PATCH /api/esc/environments/...` fails with a
+409 about a change request, the environment requires every update to be
+approved. Use the CLI's `--draft` flag — it bundles create-draft with
+submit-change-request:
 
 ```bash
-# Single-key update — recommended for small edits
-pulumi env set --draft <org>/<project>/<env> <key> <value>
-pulumi env set --draft <org>/<project>/<env> <key> <value> --secret
-
-# Full-file replace — recommended when changing structure or many keys
+pulumi env set  --draft <org>/<project>/<env> <key> <value>          # single key
+pulumi env set  --draft <org>/<project>/<env> <key> <value> --secret # single secret
 pulumi env edit --draft --file /tmp/new-env.yaml <org>/<project>/<env>
 ```
 
-After the command returns, the change request is visible in the approver's
-queue and the environment is unlocked once the request is closed or applied.
+**Do not call `CreateEnvironmentDraft` / `UpdateEnvironmentDraft` directly**
+(via `pulumi cloud api` or raw HTTP). They create a draft without submitting
+it — the draft is invisible to approvers and locks the environment from
+further `--draft` operations until closed.
 
-#### What NOT to do
-
-Do **not** call `pulumi cloud api CreateEnvironmentDraft` /
-`UpdateEnvironmentDraft` directly (via `pulumi cloud api` or any raw HTTP
-client). Those endpoints create a draft but **do not** submit a change request,
-leaving an **orphan draft** that is invisible to approvers and that blocks any
-further `--draft` operations on the same environment until it is closed. The
-CLI's `--draft` wrappers above already handle the submit step; use them
-instead.
-
-If you discover an orphan draft (a `GET
-/api/change-requests/{org}/{changeRequestID}` returns status `"draft"` that you
-did not intend to leave open), find and close it:
+To clean up an orphan draft, find its change-request ID and close it (no CLI
+wrapper exists yet):
 
 ```bash
-# List open change requests for the env to find the orphan
-pulumi cloud api -X GET "/api/change-requests/<org>?entityType=environment&entityId=<env>"
-
-# Close it (no CLI wrapper exists for this today)
+pulumi cloud api -X GET  "/api/change-requests/<org>?entityType=environment&entityId=<env>"
 pulumi cloud api -X POST "/api/change-requests/<org>/<changeRequestID>/close" -d '{}'
 ```
 

--- a/authoring/skills/pulumi-esc/use_cases.yaml
+++ b/authoring/skills/pulumi-esc/use_cases.yaml
@@ -21,6 +21,11 @@ queries:
   - "Link an ESC environment to my Pulumi stack"
   - "pulumi env init - help me create a new environment"
 
+  # Approval-gated environments / change requests
+  - "How do I update an ESC environment that requires approval?"
+  - "pulumi env edit fails saying the update requires a change request"
+  - "I created an orphan draft on an ESC environment, how do I clean it up?"
+
   # Dynamic / rotating credentials
   - "Generate temporary AWS credentials for my CI/CD pipeline"
   - "I need dynamic credentials that rotate automatically"


### PR DESCRIPTION
Document the approval-gated ESC environment workflow in the `pulumi-esc` skill: use `pulumi env set --draft` / `pulumi env edit --draft` (which wrap create-draft + submit-change-request), and don't call `CreateEnvironmentDraft` / `UpdateEnvironmentDraft` directly — that produces an orphan draft that blocks future `--draft` operations. Also includes a close-out recipe for existing orphans.

Companion PR in pulumi-service updates the Neo system prompt with the same guidance: pulumi/pulumi-service#43467

Refs pulumi/pulumi-service#43463.

## Test plan

- [ ] `uv run pytest tests/test_skill_selection_accuracy.py -v`
- [ ] `uv run pytest tests/test_skill_quality.py -v -s`
- [ ] After merge: bump `cmd/agents/src/agents_py/agent-skills.sha` in pulumi-service via `scripts/install-agent-skills.sh latest`