### PR TITLE
Audit upgrade-provider doc replacements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,9 +175,16 @@ uv run pytest tests/ -v
 4. Add `use_cases.yaml` with representative trigger queries (see [Testing](#testing) above)
 5. Update this AGENTS.md file to list the new skill in the appropriate plugin section
 6. Update [README.md](README.md) to add the skill to the skills table
-7. Submit a pull request
+7. Bump the containing plugin's patch version in both `<plugin>/.claude-plugin/plugin.json` and `<plugin>/.codex-plugin/plugin.json`
+8. Submit a pull request
 
-The skill will automatically be included in its plugin group. No manifest updates are needed.
+The skill will automatically be included in its plugin group, but installed plugin users need a plugin version bump to receive changed plugin contents. Any change under an existing plugin directory that affects shipped skills, references, agents, hooks, MCP config, or install-surface metadata must bump that plugin's version in both ecosystem manifests. Use a patch bump for skill-content and routing changes unless the change is intentionally breaking or feature-sized.
+
+Examples:
+
+- Editing `package-maintenance/skills/pulumi-upgrade-provider/SKILL.md` requires bumping both `package-maintenance/.claude-plugin/plugin.json` and `package-maintenance/.codex-plugin/plugin.json`.
+- Adding `pulumi/skills/new-skill/` requires bumping both `pulumi/.claude-plugin/plugin.json` and `pulumi/.codex-plugin/plugin.json`.
+- Creating a brand-new plugin group starts with its initial manifest version; no additional bump is needed in the same PR.
 
 ## Creating a New Plugin Group
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,25 +195,27 @@ Before submitting a skill, verify:
 
 ### New Skills
 
-1. Determine which plugin group the skill belongs to (migration or pulumi)
+1. Determine which plugin group the skill belongs to (migration, pulumi, delegation, or package-maintenance)
 2. Create a new directory under `<plugin>/skills/` with the skill name
 3. Add a `SKILL.md` file following the format above
 4. Update [AGENTS.md](AGENTS.md) to list the new skill in the appropriate plugin section
 5. Update [README.md](README.md) to add the skill to the skills table
-6. Test the skill with at least one AI coding assistant
-7. Submit a pull request with:
+6. Bump the containing plugin's patch version in both `<plugin>/.claude-plugin/plugin.json` and `<plugin>/.codex-plugin/plugin.json`
+7. Test the skill with at least one AI coding assistant
+8. Submit a pull request with:
    - Description of what the skill does
    - Example prompts that trigger the skill
    - Testing notes
 
-The skill will automatically be included in its plugin group. No manifest updates are needed.
+The skill will automatically be included in its plugin group, but installed plugin users need a plugin version bump to receive changed plugin contents. Use a patch bump for new skills and non-breaking skill-content updates unless the change is intentionally breaking or feature-sized.
 
 ### Improving Existing Skills
 
 1. Fork the repository
 2. Make your changes
-3. Test the changes with an AI coding assistant
-4. Submit a pull request with:
+3. Bump the containing plugin's patch version in both `<plugin>/.claude-plugin/plugin.json` and `<plugin>/.codex-plugin/plugin.json`
+4. Test the changes with an AI coding assistant
+5. Submit a pull request with:
    - What you changed and why
    - Before/after examples if applicable
 

--- a/package-maintenance/.claude-plugin/plugin.json
+++ b/package-maintenance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-package-maintenance",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Maintain Pulumi provider repositories: run upgrade-provider and manage upstream Terraform patches",
   "author": {
     "name": "Pulumi",

--- a/package-maintenance/.codex-plugin/plugin.json
+++ b/package-maintenance/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-package-maintenance",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Maintain Pulumi provider repositories: run upgrade-provider and manage upstream Terraform patches",
   "skills": "./skills/",
   "author": {

--- a/package-maintenance/skills/pulumi-upgrade-provider/SKILL.md
+++ b/package-maintenance/skills/pulumi-upgrade-provider/SKILL.md
@@ -63,7 +63,26 @@ The tool creates a PR on successful upgrade.
 gh pr view --json url --jq .url || gh pr list --head "$(git branch --show-current)" --json url --jq '.[0].url'
 ```
 
-2. MUST append a "Fixes applied to unblock upgrade" section to the existing PR body if any fixes were applied (do not overwrite):
+2. MUST audit generated doc replacements for unresolved placeholders:
+
+```console
+if [ -f provider/replacements.json ]; then
+  rg -n '"new":.*TODO|TODO' provider/replacements.json || true
+fi
+```
+
+If any `TODO` is found in `provider/replacements.json`:
+- Treat it as a post-upgrade blocker; replacement values render into generated docs.
+- Inspect each `old`/`new` pair and replace `TODO` with concrete Pulumi-facing wording, usually `Pulumi`, `this provider`, or `the provider`.
+- Run focused validation if the repo has the test:
+
+```console
+cd provider && go test -v -run TestReplacementDoesNotIncludeTodos .
+```
+
+After the upgrade-provider tool has created the PR, fix these placeholders as normal follow-up work.
+
+3. MUST append a "Fixes applied to unblock upgrade" section to the existing PR body if any fixes were applied (do not overwrite):
 
 ```console
 repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
@@ -91,7 +110,8 @@ Use REST (`gh api`) instead of `gh pr edit` to avoid GraphQL project-card errors
 
 ## Guardrails
 
-- Never commit, push, or create branches manually; only run read-only git commands.
+- Never commit, push, or create branches manually during the upgrade-provider run loop; only run read-only git commands.
+- After the tool creates a PR, follow-up commits are permitted for post-run fixes.
 - `./scripts/upstream.sh checkout|rebase|check_in` are allowed because the tool manages git state.
 - Do not stash changes; the tool manages git state.
 

--- a/package-maintenance/skills/pulumi-upgrade-provider/use_cases.yaml
+++ b/package-maintenance/skills/pulumi-upgrade-provider/use_cases.yaml
@@ -7,3 +7,4 @@ queries:
   - "upgrade-provider failed with unknown revision v0.0.0 from an upstream replace directive"
   - "make tfgen is failing after an upgrade-provider run because a new resource is missing module mapping"
   - "make generate_sdks failed with a duplicate .NET file during a Pulumi provider upgrade"
+  - "A provider upgrade PR review says provider/replacements.json contains TODO placeholders"


### PR DESCRIPTION
## Summary
- Add a post-run audit for unresolved `TODO` placeholders in `provider/replacements.json` after `upgrade-provider` creates a PR.
- Clarify that generated replacement TODOs are post-upgrade blockers because they can render into docs.
- Scope commit guardrails to the upgrade-provider run loop and explicitly permit post-PR follow-up commits for post-run fixes.
- Add a routing use case for PR review feedback about replacements TODO placeholders.
- Bump the package-maintenance plugin manifests to `1.0.1` for Claude and Codex distribution.
- Update contributor and agent docs so future skill changes include the required plugin version bump.

## Versioning
Bumped `pulumi-package-maintenance` from `1.0.0` to `1.0.1` in both manifests. Claude Code docs explicitly state that when a plugin manifest has a `version`, users only receive updates when that field is bumped. Codex docs show plugin manifests carrying a version and advise making the plugin version ready before marketplace publication; installed Codex plugin caches are also version-keyed, so this patch bump is the safest release signal for installed users.

## Validation
- `git diff --check`
- `uv run pytest tests/test_manifests.py -v`

Attempted but not completed locally:
- `uv run pytest tests/test_skill_selection_accuracy.py -v` failed before evaluation because `ANTHROPIC_API_KEY` was not configured: `Could not resolve authentication method`.
