### PR TITLE
Update provider upgrade skills for review-before-submit

### DIFF
--- a/package-maintenance/.claude-plugin/plugin.json
+++ b/package-maintenance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-package-maintenance",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Maintain Pulumi provider repositories: run upgrade-provider and manage upstream Terraform patches",
   "author": {
     "name": "Pulumi",

--- a/package-maintenance/.claude-plugin/plugin.json
+++ b/package-maintenance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-package-maintenance",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Maintain Pulumi provider repositories: run upgrade-provider and manage upstream Terraform patches",
   "author": {
     "name": "Pulumi",

--- a/package-maintenance/.codex-plugin/plugin.json
+++ b/package-maintenance/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-package-maintenance",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Maintain Pulumi provider repositories: run upgrade-provider and manage upstream Terraform patches",
   "skills": "./skills/",
   "author": {

--- a/package-maintenance/.codex-plugin/plugin.json
+++ b/package-maintenance/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-package-maintenance",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Maintain Pulumi provider repositories: run upgrade-provider and manage upstream Terraform patches",
   "skills": "./skills/",
   "author": {

--- a/package-maintenance/skills/pulumi-upgrade-provider/SKILL.md
+++ b/package-maintenance/skills/pulumi-upgrade-provider/SKILL.md
@@ -7,32 +7,55 @@ description: Automate Pulumi provider repo upgrades with the `upgrade-provider` 
 
 ## Overview
 
-Run `upgrade-provider`, fix known failures, and rerun until success. Keep git operations read-only in the repo; the tool owns branch/commit/PR state.
+Run `upgrade-provider --no-submit`, fix known failures, and rerun until success. During the run loop, the tool owns branch and generated-commit state but does not push or mutate GitHub. After success, review and correct the local result before submitting it using the plan printed by the tool.
+
+## Preflight
+
+1. Inspect existing changes, especially untracked files:
+
+```bash
+git status --short --untracked-files=all
+git ls-files --others --exclude-standard
+```
+
+The tool still stages broadly, so do not proceed until every existing path is intentional upgrade input. Move or remove unrelated files, or add local-only artifacts to `.git/info/exclude`. Do not add a repository `.gitignore` rule unless the path should be ignored for all contributors, and do not stash changes.
+
+2. Keep the run log outside the repository so the tool cannot stage it.
 
 ## Run Loop
 
-1. Create output directory:
+1. Run from repo root:
 
 ```bash
-mkdir -p .pulumi
+log_file="${TMPDIR:-/tmp}/upgrade-provider-$(basename "$PWD").log"
+upgrade-provider $ORG/$REPO --repo-path . --no-submit > "$log_file" 2> /dev/null
 ```
 
-2. Run from repo root:
+Preserve `--no-submit` on every retry.
+
+2. Wait for completion (can take up to 10 minutes).
+3. Check for errors by scanning the log for lines starting with `error: `:
 
 ```bash
-upgrade-provider $ORG/$REPO --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
+if command -v rg >/dev/null 2>&1; then
+  rg -n '^error: ' "$log_file" || true
+else
+  grep -n '^error: ' "$log_file" || true
+fi
 ```
 
-3. Wait for completion (can take up to 10 minutes).
-4. Check for errors by scanning `.pulumi/upgrade-provider-stdout.txt` lines starting with `error: `.
-5. If failed, fix using this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo), then rerun. For upstream `go get` failures involving ignored `replace` directives or `unknown revision v0.0.0`, rerun with `--target-version` after applying the documented `provider/go.mod` replacements; preserve the original major/non-major intent and add `--major` only for actual major version upgrades.
-6. If a fix requires creating/amending/removing/rebasing patches, use the `upstream-patches` skill for the patch workflow.
+4. On success, extract and read the complete local-completion report from the captured stdout:
+
+```bash
+awk '/^Upgrade completed locally;/{found=1} found' "$log_file"
+```
+
+This includes the proposed PR body and metadata, review commands, and every skipped submission action.
+
+5. If failed, fix using this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo), then rerun with `--no-submit`. For upstream `go get` failures involving ignored `replace` directives or `unknown revision v0.0.0`, rerun with `--target-version` after applying the documented `provider/go.mod` replacements; preserve the original major/non-major intent and add `--major` only for actual major version upgrades.
+6. If a fix requires creating/amending/removing/rebasing patches, use the `upstream-patches` skill for the patch workflow. Interrupted patch workflows must be checked in before rerunning.
 7. If you fixed a conflict, report exact edits (file paths + concrete changes or preserved intent).
-8. If the upgrade changed patches, run `./scripts/upstream.sh checkout` and review applied `upstream` commits:
-   - List commit SHAs/titles from `upstream`.
-   - Summarize the intent of each commit in plain language.
-   - Call out any behavioral changes or risks.
-9. On success, proceed to Post-run Tasks.
+8. Repeat until the tool prints the local-completion report and proposed PR plan. This run must not push or mutate GitHub; a branch or PR from an earlier run may already exist.
 
 ## When to Stop and Report Failure
 
@@ -41,7 +64,8 @@ Stop iterating and report failure if any of these conditions are met:
 1. **Command not found (exit code 127)**: The `upgrade-provider` tool is not in PATH.
 2. **Same error 3 times**: You've attempted to fix the same error 3 times without success.
 3. **Unknown error pattern**: The error is not covered in `references/upgrade-provider-errors.md` and you cannot determine a safe fix.
-4. **Requires human judgment**: The fix needs user input, such as:
+4. **Ambiguous patch state**: You cannot prove that every patch was applied and the target rebase completed.
+5. **Requires human judgment**: The fix needs user input, such as:
    - Choosing between multiple valid approaches
    - Breaking changes that affect public API
    - Deprecation strategies
@@ -53,38 +77,94 @@ When stopping, report:
 3. Why human intervention is needed.
 4. Any partial progress.
 
-## Post-run Tasks
+## Review the Local Upgrade
 
-The tool creates a PR on successful upgrade.
+Use the tool's final report as the source of truth for the base branch, working branch, proposed PR title/body/metadata, and skipped submission actions.
 
-1. MUST fetch the PR URL for the current branch using read-only commands:
+1. Review a bounded summary first:
 
-```console
-gh pr view --json url --jq .url || gh pr list --head "$(git branch --show-current)" --json url --jq '.[0].url'
+```bash
+default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+base_ref="origin/$default_branch"
+git status --short --untracked-files=all
+git log --oneline "$base_ref"..HEAD
+git diff --shortstat "$base_ref"...HEAD
+git diff --name-only "$base_ref"...HEAD | awk -F/ '{print $1}' | sort | uniq -c
 ```
 
-2. MUST audit generated doc replacements for unresolved placeholders:
+Provider upgrades can change thousands of generated SDK files. Do not print the full branch diff by default. Use path-limited `git diff "$base_ref"...HEAD -- <paths>` commands to inspect source, configuration, patch, schema, and unexpected directories. For generated SDKs, inspect summaries or targeted files unless a full diff is necessary.
 
-```console
+If unrelated or sensitive files entered a local commit, do not push; remove them from the unpublished branch history first. Revoke any exposed credential even if the history is rewritten.
+
+2. MUST audit generated doc replacements for unresolved placeholders before publication:
+
+```bash
 if [ -f provider/replacements.json ]; then
-  rg -n '"new":.*TODO|TODO' provider/replacements.json || true
+  if command -v rg >/dev/null 2>&1; then
+    rg -n '"new":.*TODO|TODO' provider/replacements.json || true
+  else
+    grep -En '"new":.*TODO|TODO' provider/replacements.json || true
+  fi
 fi
 ```
 
 If any `TODO` is found in `provider/replacements.json`:
-- Treat it as a post-upgrade blocker; replacement values render into generated docs.
+- Treat it as a pre-submission blocker; replacement values render into generated docs.
 - Inspect each `old`/`new` pair and replace `TODO` with concrete Pulumi-facing wording, usually `Pulumi`, `this provider`, or `the provider`.
 - Run focused validation if the repo has the test:
 
-```console
+```bash
 cd provider && go test -v -run TestReplacementDoesNotIncludeTodos .
 ```
 
-After the upgrade-provider tool has created the PR, fix these placeholders as normal follow-up work.
+3. If the upgrade changed patches, review the applied commits and then exit checkout mode:
 
-3. MUST append a "Fixes applied to unblock upgrade" section to the existing PR body if any fixes were applied (do not overwrite):
+```bash
+./scripts/upstream.sh checkout
+git -C upstream log --oneline pulumi/checkout-base..pulumi/patch-checkout
+# Inspect relevant commits with git -C upstream show <sha>.
+./scripts/upstream.sh check_in
+```
 
-```console
+List commit SHAs/titles, summarize each intent, and call out behavioral changes or risks. `check_in` is mandatory after review; leaving `upstream` on `pulumi/patch-checkout` blocks the next safe tool run.
+
+4. Run focused validation for every manual fix and add focused follow-up commits.
+5. Require a clean working tree before submission.
+
+## Submit the Reviewed Upgrade
+
+The local-completion report lists the proposed PR metadata and every skipped action. MUST reproduce all applicable actions, not only PR creation:
+
+1. Preserve the proposed title, body, release label, reviewers, and assignee.
+2. If fixes unblocked the upgrade, append this section to the proposed body before submission when practical:
+
+```markdown
+---
+
+### Fixes applied to unblock upgrade
+
+- <list concrete unblocker edits here, with file paths and intent>
+```
+
+3. Push only after review. The tool reports an unconditional force-push; manual submission intentionally uses the safer lease-protected equivalent unless the user explicitly approves overwriting newer remote work:
+
+```bash
+branch=$(git branch --show-current)
+git push --set-upstream origin "$branch" --force-with-lease
+```
+
+4. Use `gh` to create or update the PR as described by the report.
+5. Assign listed upgrade issues to the PR assignee when requested.
+6. For bridge upgrades, close listed superseded bridge PRs and comment with the replacement PR URL.
+7. Fetch and report the final PR URL:
+
+```bash
+gh pr view --json url --jq .url || gh pr list --head "$(git branch --show-current)" --json url --jq '.[0].url'
+```
+
+If the fixes section was not included before submission, append it without replacing the existing body:
+
+```bash
 repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 pr_number=$(gh pr view --json number --jq .number)
 gh pr view --json body --jq .body > /tmp/pr_body.txt
@@ -110,11 +190,12 @@ Use REST (`gh api`) instead of `gh pr edit` to avoid GraphQL project-card errors
 
 ## Guardrails
 
-- Never commit, push, or create branches manually during the upgrade-provider run loop; only run read-only git commands.
-- After the tool creates a PR, follow-up commits are permitted for post-run fixes.
-- `./scripts/upstream.sh checkout|rebase|check_in` are allowed because the tool manages git state.
-- Do not stash changes; the tool manages git state.
+- Never commit, push, or create branches manually during the upgrade-provider run loop.
+- After `--no-submit` succeeds, focused correction commits and manual submission are permitted.
+- Never use `./scripts/upstream.sh init -f` unless intentionally discarding interrupted patch work; it is destructive.
+- Do not leave `upstream` in checkout or an active Git operation before submission.
+- Do not stash changes; use a clean worktree or remove unrelated artifacts instead.
 
 ## References
 
-- Use this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo) for patch conflict, ignored upstream replacement, vendored upstream dependency, .NET duplicate file, and new module mapping fixes.
+- Use this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo) for interrupted patch state, patch conflict, ignored upstream replacement, vendored upstream dependency, .NET duplicate file, and new module mapping fixes.

--- a/package-maintenance/skills/pulumi-upgrade-provider/SKILL.md
+++ b/package-maintenance/skills/pulumi-upgrade-provider/SKILL.md
@@ -11,14 +11,14 @@ Run `upgrade-provider --no-submit`, fix known failures, and rerun until success.
 
 ## Preflight
 
-1. Inspect existing changes, especially untracked files:
+1. Record existing changes as the pre-upgrade baseline:
 
 ```bash
-git status --short --untracked-files=all
-git ls-files --others --exclude-standard
+baseline_file="${TMPDIR:-/tmp}/upgrade-provider-$(basename "$PWD")-baseline.txt"
+git status --short --untracked-files=all | tee "$baseline_file"
 ```
 
-The tool still stages broadly, so do not proceed until every existing path is intentional upgrade input. Move or remove unrelated files, or add local-only artifacts to `.git/info/exclude`. Do not add a repository `.gitignore` rule unless the path should be ignored for all contributors, and do not stash changes.
+Existing changes do not block the upgrade, but the tool stages broadly and may include them in generated commits. If practical, isolate clearly unrelated work in another branch or worktree, move local-only files, or add untracked local artifacts to `.git/info/exclude`. Otherwise proceed and carry this baseline into the final review. Do not add a repository `.gitignore` rule unless the path should be ignored for all contributors.
 
 2. Keep the run log outside the repository so the tool cannot stage it.
 
@@ -94,7 +94,14 @@ git diff --name-only "$base_ref"...HEAD | awk -F/ '{print $1}' | sort | uniq -c
 
 Provider upgrades can change thousands of generated SDK files. Do not print the full branch diff by default. Use path-limited `git diff "$base_ref"...HEAD -- <paths>` commands to inspect source, configuration, patch, schema, and unexpected directories. For generated SDKs, inspect summaries or targeted files unless a full diff is necessary.
 
-If unrelated or sensitive files entered a local commit, do not push; remove them from the unpublished branch history first. Revoke any exposed credential even if the history is rewritten.
+Cross-check the final branch against the pre-upgrade baseline:
+
+```bash
+baseline_file="${TMPDIR:-/tmp}/upgrade-provider-$(basename "$PWD")-baseline.txt"
+[ ! -f "$baseline_file" ] || cat "$baseline_file"
+```
+
+For every pre-existing path included in the branch, decide whether it belongs in the upgrade PR. Keep intentional paths; move unrelated work to another branch/worktree or remove it from the unpublished upgrade history before pushing. A separate commit on the same branch isolates history but does not remove the path from the PR, and unstaging alone is insufficient after the tool has committed it. Revoke any exposed credential even if the history is rewritten.
 
 2. MUST audit generated doc replacements for unresolved placeholders before publication:
 

--- a/package-maintenance/skills/pulumi-upgrade-provider/SKILL.md
+++ b/package-maintenance/skills/pulumi-upgrade-provider/SKILL.md
@@ -52,7 +52,7 @@ awk '/^Upgrade completed locally;/{found=1} found' "$log_file"
 
 This includes the proposed PR body and metadata, review commands, and every skipped submission action.
 
-5. If failed, fix using this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo), then rerun with `--no-submit`. For upstream `go get` failures involving ignored `replace` directives or `unknown revision v0.0.0`, rerun with `--target-version` after applying the documented `provider/go.mod` replacements; preserve the original major/non-major intent and add `--major` only for actual major version upgrades.
+5. If failed, fix using this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo), then rerun with `--no-submit`. If upstream migrated from Terraform Plugin SDKv2 to Plugin Framework, use the migration-guide routing in that reference instead of treating the framework change alone as an architectural blocker. For upstream `go get` failures involving ignored `replace` directives or `unknown revision v0.0.0`, rerun with `--target-version` after applying the documented `provider/go.mod` replacements; preserve the original major/non-major intent and add `--major` only for actual major version upgrades.
 6. If a fix requires creating/amending/removing/rebasing patches, use the `upstream-patches` skill for the patch workflow. Interrupted patch workflows must be checked in before rerunning.
 7. If you fixed a conflict, report exact edits (file paths + concrete changes or preserved intent).
 8. Repeat until the tool prints the local-completion report and proposed PR plan. This run must not push or mutate GitHub; a branch or PR from an earlier run may already exist.
@@ -65,11 +65,7 @@ Stop iterating and report failure if any of these conditions are met:
 2. **Same error 3 times**: You've attempted to fix the same error 3 times without success.
 3. **Unknown error pattern**: The error is not covered in `references/upgrade-provider-errors.md` and you cannot determine a safe fix.
 4. **Ambiguous patch state**: You cannot prove that every patch was applied and the target rebase completed.
-5. **Requires human judgment**: The fix needs user input, such as:
-   - Choosing between multiple valid approaches
-   - Breaking changes that affect public API
-   - Deprecation strategies
-   - Architectural decisions about module organization
+5. **Requires human judgment**: The fix needs user input, such as choosing between multiple valid implementation approaches or making an architectural decision about module organization. Upstream breaking changes, deprecations, or framework migrations do not by themselves require stopping; stop only when implementing the upgrade presents an unresolved choice.
 
 When stopping, report:
 1. The error(s) encountered.
@@ -142,7 +138,7 @@ List commit SHAs/titles, summarize each intent, and call out behavioral changes 
 
 The local-completion report lists the proposed PR metadata and every skipped action. MUST reproduce all applicable actions, not only PR creation:
 
-1. Preserve the proposed title, body, release label, reviewers, and assignee.
+1. Preserve the proposed title, body, release label, reviewers, and assignee. Never decide, infer, or change the release label: provider upgrades follow the upstream version transition, so the label represents that version delta rather than the agent's assessment of whether individual changes are breaking. For example, upstream `v0.9.0` to `v0.10.0` remains a minor upgrade even when it contains breaking behavioral changes. Use exactly the label emitted by `upgrade-provider`, report any concern to reviewers without changing the metadata, and never add `--major` unless the upstream target crosses the current upstream major version.
 2. If fixes unblocked the upgrade, append this section to the proposed body before submission when practical:
 
 ```markdown
@@ -205,4 +201,4 @@ Use REST (`gh api`) instead of `gh pr edit` to avoid GraphQL project-card errors
 
 ## References
 
-- Use this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo) for interrupted patch state, patch conflict, ignored upstream replacement, vendored upstream dependency, .NET duplicate file, and new module mapping fixes.
+- Use this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo) for interrupted patch state, patch conflict, SDKv2-to-Plugin-Framework migration, ignored upstream replacement, vendored upstream dependency, .NET duplicate file, and new module mapping fixes.

--- a/package-maintenance/skills/pulumi-upgrade-provider/SKILL.md
+++ b/package-maintenance/skills/pulumi-upgrade-provider/SKILL.md
@@ -44,7 +44,17 @@ else
 fi
 ```
 
-4. On success, extract and read the complete local-completion report from the captured stdout:
+4. On a successful exit, first check whether the tool found that no upgrade was required:
+
+```bash
+if grep -Fq 'No actions needed' "$log_file"; then
+  echo 'No actions needed'
+fi
+```
+
+If present, report that the provider is already current or the requested target is not an upgrade, then stop successfully. There is no local upgrade to review or submit.
+
+5. Otherwise, extract and read the complete local-completion report from the captured stdout:
 
 ```bash
 awk '/^Upgrade completed locally;/{found=1} found' "$log_file"
@@ -52,10 +62,10 @@ awk '/^Upgrade completed locally;/{found=1} found' "$log_file"
 
 This includes the proposed PR body and metadata, review commands, and every skipped submission action.
 
-5. If failed, fix using this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo), then rerun with `--no-submit`. If upstream migrated from Terraform Plugin SDKv2 to Plugin Framework, use the migration-guide routing in that reference instead of treating the framework change alone as an architectural blocker. For upstream `go get` failures involving ignored `replace` directives or `unknown revision v0.0.0`, rerun with `--target-version` after applying the documented `provider/go.mod` replacements; preserve the original major/non-major intent and add `--major` only for actual major version upgrades.
-6. If a fix requires creating/amending/removing/rebasing patches, use the `upstream-patches` skill for the patch workflow. Interrupted patch workflows must be checked in before rerunning.
-7. If you fixed a conflict, report exact edits (file paths + concrete changes or preserved intent).
-8. Repeat until the tool prints the local-completion report and proposed PR plan. This run must not push or mutate GitHub; a branch or PR from an earlier run may already exist.
+6. If failed, fix using this skill's `references/upgrade-provider-errors.md` (from the skill folder, not the repo), then rerun with `--no-submit`. If upstream migrated from Terraform Plugin SDKv2 to Plugin Framework, use the migration-guide routing in that reference instead of treating the framework change alone as an architectural blocker. For upstream `go get` failures involving ignored `replace` directives or `unknown revision v0.0.0`, rerun with `--target-version` after applying the documented `provider/go.mod` replacements; preserve the original major/non-major intent and add `--major` only for actual major version upgrades.
+7. If a fix requires creating/amending/removing/rebasing patches, use the `upstream-patches` skill for the patch workflow. Interrupted patch workflows must be checked in before rerunning.
+8. If you fixed a conflict, report exact edits (file paths + concrete changes or preserved intent).
+9. Repeat until the tool prints `No actions needed` or the local-completion report and proposed PR plan. This run must not push or mutate GitHub; a branch or PR from an earlier run may already exist.
 
 ## When to Stop and Report Failure
 

--- a/package-maintenance/skills/pulumi-upgrade-provider/agents/openai.yaml
+++ b/package-maintenance/skills/pulumi-upgrade-provider/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Pulumi Upgrade Provider"
   short_description: "Upgrade providers and fix common upgrade blockers."
-  default_prompt: "Use $pulumi-upgrade-provider to run upgrade-provider for this repo, fix known failures, and summarize unblocker edits."
+  default_prompt: "Use $pulumi-upgrade-provider to complete this upgrade locally with --no-submit, fix and review the result, then submit the approved branch."

--- a/package-maintenance/skills/pulumi-upgrade-provider/references/upgrade-provider-errors.md
+++ b/package-maintenance/skills/pulumi-upgrade-provider/references/upgrade-provider-errors.md
@@ -1,7 +1,38 @@
 # Upgrade Provider Errors
 
 Use this file when the `upgrade-provider` tool fails and you need concrete fixes.
-For patch edits/removals/rebases, follow the `upstream-patches` skill workflow.
+For patch edits/removals/rebases, follow the `upstream-patches` skill workflow. Preserve `--no-submit` on every `upgrade-provider` retry.
+
+## Patched upstream has interrupted or unexpected Git state
+
+The tool deliberately leaves active Git operations, `pulumi/patch-checkout`, and unexpected branches unchanged because it cannot prove that an interrupted checkout applied the complete patch stack.
+
+Preserve work by default:
+
+1. Inspect `git -C upstream status` and identify whether `git am`, rebase, merge, cherry-pick, or another operation is active.
+2. Use skill `upstream-patches` for conflict resolution or patch edits.
+3. Complete or safely abort the active operation. If checkout was interrupted during `git am`, verify that every `patches/*.patch` was applied; later patch files may not have been reached.
+4. Ensure the patch stack was rebased onto the requested target. If needed, run the target rebase from the provider root and resolve it fully:
+
+```bash
+./scripts/upstream.sh rebase -o refs/tags/v<TARGET>
+```
+
+5. Once every patch is applied and the target rebase is complete, write patches back and exit checkout mode:
+
+```bash
+./scripts/upstream.sh check_in
+```
+
+6. Confirm `upstream` is no longer on `pulumi/patch-checkout`, then rerun `upgrade-provider` with `--no-submit`.
+
+Only when intentionally discarding all interrupted patch work may you run:
+
+```bash
+./scripts/upstream.sh init -f
+```
+
+This deletes active operation state and patch-checkout work and can clean untracked files. Treat it as destructive discard, not normal recovery.
 
 ## Patch conflicts during rebase
 
@@ -20,15 +51,21 @@ Fix from the `upstream` directory, following `upstream-patches` defaults (edit t
 3. Search for conflict markers and remove all of them before continuing.
 4. `git add` the resolved files.
 5. `git rebase --continue`.
+6. Repeat until the rebase is complete, then return to the provider root and exit checkout mode:
 
-If `git rebase --continue` opens an editor in automation contexts, run with `GIT_EDITOR=true`.
+```bash
+./scripts/upstream.sh check_in
+```
+
+7. Confirm `upstream` is detached rather than on `pulumi/patch-checkout`, then rerun `upgrade-provider` with `--no-submit`.
+
+If `git rebase --continue` opens an editor in automation contexts, run `GIT_EDITOR=true git rebase --continue`.
 
 Avoid:
 
+- Rerunning the tool before `check_in`; safe patched-provider preflight will reject leftover checkout state.
 - Hand-editing `patches/*.patch` unless intentionally doing raw patch surgery.
 - Direct edits under `upstream/` outside `checkout/check_in` workflow.
-
-After the rebase completes, rerun `upgrade-provider` from the repo root.
 
 ### Patch intent guidance
 
@@ -54,7 +91,7 @@ Fix in the Pulumi provider repo:
 5. Rerun `upgrade-provider` from the repo root with the target version explicit. Preserve the original major/non-major intent:
 
 ```bash
-upgrade-provider pulumi/<provider> --repo-path . --target-version <version>
+upgrade-provider pulumi/<provider> --repo-path . --no-submit --target-version <version>
 ```
 
 Add `--major` only when the target upstream version crosses the current upstream major version. Passing `--major` for a same-major target makes `upgrade-provider` fail and can trigger unwanted major-version rewrite behavior.
@@ -62,7 +99,7 @@ Add `--major` only when the target upstream version crosses the current upstream
 If repo tools are managed by `mise`, run under the repo environment so Go and converter plugins match CI:
 
 ```bash
-eval "$(mise env)" && upgrade-provider pulumi/<provider> --repo-path . --target-version <version>
+eval "$(mise env)" && upgrade-provider pulumi/<provider> --repo-path . --no-submit --target-version <version>
 ```
 
 Example: `pulumi-rancher2` upgrading to upstream `terraform-provider-rancher2` `v14.1.0` needed main-module replacements like:
@@ -188,7 +225,7 @@ DataSources: map[string]*tfbridge.DataSourceInfo{
 }
 ```
 
-After updating, rerun `upgrade-provider`.
+After updating, rerun `upgrade-provider` with `--no-submit`.
 
 ## .NET duplicate file from nested Get suffix collision
 
@@ -214,7 +251,7 @@ git show "origin/${default_branch}:${schema_path}" | rg "<NestedTypeName>"
 rg "<NestedTypeName>" "$schema_path"
 ```
 
-Replace `<NestedTypeName>` with the colliding nested type prefix from the duplicate filename.
+Replace `<NestedTypeName>` with the colliding nested type prefix from the duplicate filename. If `rg` is unavailable, use `grep -n` for these literal searches.
 
 Fix by applying a normal bridge `Name` override in `provider/resources.go` to rename the smallest nested field that causes the collision. Do not use `CSharpName`; it only changes C# property labels and does not change generated nested type filenames. Avoid schema post-processors unless there is no ordinary bridge mapping available.
 
@@ -241,7 +278,7 @@ Example:
 },
 ```
 
-After updating the bridge mapping, rerun `upgrade-provider` from the repo root so schema and SDKs regenerate consistently.
+After updating the bridge mapping, rerun `upgrade-provider --no-submit` from the repo root so schema and SDKs regenerate consistently.
 
 ## ID attribute wrong type (tfgen unresolved ID mapping)
 

--- a/package-maintenance/skills/pulumi-upgrade-provider/references/upgrade-provider-errors.md
+++ b/package-maintenance/skills/pulumi-upgrade-provider/references/upgrade-provider-errors.md
@@ -71,6 +71,25 @@ Avoid:
 
 - Docs-related patches usually replace or remove Terraform references. Preserve those changes when resolving conflicts.
 
+## Upstream migrated from SDKv2 to Plugin Framework
+
+Treat an upstream Terraform Plugin SDKv2-to-Plugin-Framework migration as a known migration path, not by itself as an architectural blocker. Common signals include:
+
+- Compiler errors such as `undefined: <package>.Provider` or code that still expects `*schema.Provider`.
+- Upstream `go.mod` dropping or making `terraform-plugin-sdk/v2` indirect while adding `terraform-plugin-framework`.
+- Upstream release notes or commits that announce a Plugin Framework migration or SDKv2 removal.
+
+Read the current bridge guide before editing provider entry points or imports:
+
+- Complete migration: [Upgrade a bridged provider from SDKv2 to Plugin Framework](https://github.com/pulumi/pulumi-terraform-bridge/blob/main/docs/guides/upgrade-sdk-to-pf.md).
+- Provider retaining both SDKv2 and Plugin Framework resources: [Upgrade an SDKv2 provider using mux](https://github.com/pulumi/pulumi-terraform-bridge/blob/main/docs/guides/upgrade-sdk-to-mux.md) ([rendered documentation](https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/upgrade-sdk-to-mux.html)).
+
+Do not rely on remembered import paths or API signatures. The guides describe the current bridge release; verify the packages and APIs against the `pulumi-terraform-bridge` version selected by `provider/go.mod` before applying the migration.
+
+First look for a public upstream package that constructs the Plugin Framework provider. If upstream exposes the constructor only from an unimportable `internal/` package, use skill `upstream-patches` to add the smallest non-internal shim that returns the upstream provider. This is a legitimate new-patch case; keep the patch limited to exposing the constructor and document when it can be removed.
+
+After applying the appropriate guide and any required patch, run focused provider builds or tests, then rerun `upgrade-provider` with `--no-submit`.
+
 ## Upstream provider relies on ignored replace directives
 
 When `upgrade-provider` fails during `Update TF Provider` with an upstream module resolution error like:

--- a/package-maintenance/skills/pulumi-upgrade-provider/use_cases.yaml
+++ b/package-maintenance/skills/pulumi-upgrade-provider/use_cases.yaml
@@ -10,4 +10,5 @@ queries:
   - "make generate_sdks failed with a duplicate .NET file during a Pulumi provider upgrade"
   - "A provider upgrade PR review says provider/replacements.json contains TODO placeholders"
   - "Run upgrade-provider locally with --no-submit so I can review and fix the generated changes before opening a PR"
+  - "upgrade-provider exited successfully with No actions needed; is the provider already current?"
   - "upgrade-provider says the patched upstream repository is still on pulumi/patch-checkout; help me preserve the work and finish the upgrade"

--- a/package-maintenance/skills/pulumi-upgrade-provider/use_cases.yaml
+++ b/package-maintenance/skills/pulumi-upgrade-provider/use_cases.yaml
@@ -5,6 +5,7 @@ queries:
   - "Upgrade this Pulumi provider repository to Terraform provider v2.0.0 with upgrade-provider"
   - "The provider upgrade failed with patch conflicts in upstream; help me resolve and rerun upgrade-provider"
   - "upgrade-provider failed with unknown revision v0.0.0 from an upstream replace directive"
+  - "The upstream Terraform provider migrated from SDKv2 to Plugin Framework and upgrade-provider no longer compiles"
   - "make tfgen is failing after an upgrade-provider run because a new resource is missing module mapping"
   - "make generate_sdks failed with a duplicate .NET file during a Pulumi provider upgrade"
   - "A provider upgrade PR review says provider/replacements.json contains TODO placeholders"

--- a/package-maintenance/skills/pulumi-upgrade-provider/use_cases.yaml
+++ b/package-maintenance/skills/pulumi-upgrade-provider/use_cases.yaml
@@ -8,3 +8,5 @@ queries:
   - "make tfgen is failing after an upgrade-provider run because a new resource is missing module mapping"
   - "make generate_sdks failed with a duplicate .NET file during a Pulumi provider upgrade"
   - "A provider upgrade PR review says provider/replacements.json contains TODO placeholders"
+  - "Run upgrade-provider locally with --no-submit so I can review and fix the generated changes before opening a PR"
+  - "upgrade-provider says the patched upstream repository is still on pulumi/patch-checkout; help me preserve the work and finish the upgrade"

--- a/package-maintenance/skills/upstream-patches/SKILL.md
+++ b/package-maintenance/skills/upstream-patches/SKILL.md
@@ -17,7 +17,7 @@ description: Create, amend, remove, and rebase patches for Terraform provider su
 | Command | Description |
 |---------|-------------|
 | `./scripts/upstream.sh init` | Initialize upstream and apply patches to working directory |
-| `./scripts/upstream.sh init -f` | Force re-initialize, discarding any changes |
+| `./scripts/upstream.sh init -f` | Destructively discard checkout/rebase state and re-initialize upstream |
 | `./scripts/upstream.sh checkout` | Create branch with patches as commits for editing |
 | `./scripts/upstream.sh rebase -i` | Interactively edit patch commits |
 | `./scripts/upstream.sh rebase -o <commit>` | Rebase patches onto a new upstream commit |
@@ -54,7 +54,7 @@ git log --oneline pulumi/patch-checkout -- path/to/file
 cd ..
 ```
 
-Set `target_sha` to the owning commit and edit that commit, not `HEAD`.
+If `rg` is unavailable, use `grep -En` for the patch search. Set `target_sha` to the owning commit and edit that commit, not `HEAD`.
 
 ## Amend Existing Patch (Preferred, Non-Interactive)
 
@@ -165,4 +165,8 @@ After `check_in`:
 - Verify target patch number/purpose is still present when expected.
 - Verify no unexpected new `00NN-*.patch` was introduced.
 
-If checkout mode is stuck, use `./scripts/upstream.sh init -f` to reset.
+## Interrupted Checkout or Rebase
+
+Preserve work by default. Inspect `git -C upstream status`, complete the active `git am`/rebase, verify that every patch was applied, and run `./scripts/upstream.sh check_in` before rerunning automation. An interrupted checkout invokes `git am` separately for each patch, so later patch files may not have been reached.
+
+Use `./scripts/upstream.sh init -f` only when intentionally discarding all interrupted work. It can remove conflict resolution, patch commits, operation metadata, and untracked files; it is not routine recovery for a stuck checkout.

--- a/package-maintenance/skills/upstream-patches/agents/openai.yaml
+++ b/package-maintenance/skills/upstream-patches/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Upstream Patches"
   short_description: "Manage upstream Terraform patch stacks in provider repos."
-  default_prompt: "Use $upstream-patches to find owning patches, amend or remove patch content safely, and verify patch set integrity."
+  default_prompt: "Use $upstream-patches to find owning patches, safely edit or recover the patch stack, check it in, and verify its integrity."

--- a/package-maintenance/skills/upstream-patches/use_cases.yaml
+++ b/package-maintenance/skills/upstream-patches/use_cases.yaml
@@ -1,0 +1,7 @@
+# Queries that should activate the upstream-patches skill
+queries:
+  - "Rebase this Pulumi provider's upstream Terraform patches onto the new upstream release"
+  - "Find which patch owns this upstream file change and amend that patch commit"
+  - "Remove one hunk from an existing patches/*.patch file using scripts/upstream.sh"
+  - "upgrade-provider left upstream on pulumi/patch-checkout during a conflict; help me preserve and check in the patch work"
+  - "Create a new upstream patch for this bridged Pulumi provider"


### PR DESCRIPTION
## Summary

- update `pulumi-upgrade-provider` to run upgrades locally with `--no-submit`, extract the final submission plan, and review/fix the branch before publication
- add broad-staging safeguards and bounded diff guidance for upgrades that generate thousands of SDK files
- align patch conflict and interrupted-checkout recovery with the fail-safe behavior in `upgrade-provider`, including mandatory `check_in` and explicit warnings around destructive `init -f`
- update package-maintenance prompts/routing cases and bump both plugin manifests to `1.0.2`

## Why

Recent `upgrade-provider` changes now propagate Git identity into patched submodules, support a review-before-submit workflow, and fail safely instead of guessing how to recover ambiguous patch state:

- pulumi/upgrade-provider#383
- pulumi/upgrade-provider#384
- pulumi/upgrade-provider#385

The skills should use those tool guarantees directly while retaining protection against pre-existing untracked files, which the tool can still stage broadly.

## Validation

- `uv run pytest tests/test_manifests.py -v` (10 passed)
- parsed changed skill frontmatter and YAML files
- `git diff --check`

LLM routing and quality tests were not run because `ANTHROPIC_API_KEY` is not available in this environment.
