### PR TITLE
package-usage: fetch data via the pulumi api CLI

### DIFF
--- a/pulumi/skills/package-usage/SKILL.md
+++ b/pulumi/skills/package-usage/SKILL.md
@@ -5,17 +5,23 @@ description: Track which stacks across a Pulumi organization use a specific pack
 
 ## API Reference
 
+Query the Pulumi Cloud API with the `pulumi api` CLI subcommand. It authenticates with your existing Pulumi credentials and returns JSON.
+
 ### Get the latest version of a package
 
-`GET /api/registry/packages?name={package_name}&orgLogin={orgName}`
+```
+pulumi api /api/registry/packages -F name={package_name} -F orgLogin={orgName}
+```
 
-You must include the `orgLogin` parameter with the user's organization name. The response contains a `packages` array. Each entry has a `version` field (the latest version), plus `name`, `publisher`, `source`, and `packageStatus`.
+Include `orgLogin` with the user's organization name. Omit `-F name=...` to list all packages visible to the organization (useful when the user has not named a specific package). The response contains a `packages` array. Each entry has a `version` field (the latest version), plus `name`, `publisher`, `source`, and `packageStatus`.
 
 ### Get stack usage for a package
 
-`GET /api/orgs/{orgName}/packages/usage?packageName={package_name}`
+```
+pulumi api /api/orgs/{orgName}/packages/usage -F packageName={package_name}
+```
 
-Replace `{orgName}` with the org name from context, `PULUMI_ORG`, or ask the user.
+Replace `{orgName}` with the org name from context, `PULUMI_ORG`, or ask the user. `packageName` is required; query one package at a time.
 
 Response fields:
 - `packageName`: The queried package

--- a/pulumi/skills/pulumi-esc/SKILL.md
+++ b/pulumi/skills/pulumi-esc/SKILL.md
@@ -200,7 +200,7 @@ Available API endpoints include:
 - `GET /api/esc/environments/{orgName}/{projectName}/{envName}` - Read environment definition
 - `GET /api/esc/providers?orgName={orgName}` - List available providers
 
-Use `call_pulumi_cloud_api()` tool to make requests when needed.
+Use the `pulumi api` CLI subcommand to make requests when needed, e.g. `pulumi api /api/esc/providers -F orgName={orgName}`.
 
 ## Best Practices
 


### PR DESCRIPTION
The package-usage skill documented its two data sources as raw HTTP endpoints (`GET /api/registry/packages?...`), leaving it to the agent to work out how to actually issue the requests. The `pulumi api` CLI subcommand is the supported way to call the Pulumi Cloud API from a shell: it handles authentication, backend URL resolution, and JSON output.

This rewrites the API reference in `pulumi api` terms:

- `pulumi api /api/registry/packages -F name=... -F orgLogin=...` for the latest-version lookup, with a note that omitting the `name` filter lists all packages visible to the organization. That gives the agent a package discovery path for questions that don't name a specific package ("do any of my stacks use outdated components?").
- `pulumi api /api/orgs/{orgName}/packages/usage -F packageName=...` for per-stack usage, noting `packageName` is required.

Workflow, output format, and the provider-upgrade hand-off are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
