### PR TITLE
Add carried patch policy to upstream-patches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Entry-point and specialized skills for writing and operating Pulumi infrastructu
 Skills for maintaining Pulumi provider repositories (provider authors and bridge maintainers):
 
 - **pulumi-upgrade-provider**: Automate Pulumi provider repo upgrades with the upgrade-provider tool
-- **upstream-patches**: Create, amend, remove, and rebase patches for Terraform provider submodules
+- **upstream-patches**: Evaluate, create, amend, remove, and rebase patches for Terraform provider submodules
 
 ### Delegation Plugin (`delegation/`)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Maintain Pulumi provider repositories (provider authors and bridge maintainers):
 | Skill | Description |
 |-------|-------------|
 | [pulumi-upgrade-provider](package-maintenance/skills/pulumi-upgrade-provider) | Automate Pulumi provider repo upgrades |
-| [upstream-patches](package-maintenance/skills/upstream-patches) | Manage upstream Terraform patch stacks in provider repos |
+| [upstream-patches](package-maintenance/skills/upstream-patches) | Evaluate patch policy and manage upstream Terraform patch stacks in provider repos |
 
 ### Delegation Skills
 

--- a/package-maintenance/.claude-plugin/plugin.json
+++ b/package-maintenance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-package-maintenance",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Maintain Pulumi provider repositories: run upgrade-provider and manage upstream Terraform patches",
   "author": {
     "name": "Pulumi",

--- a/package-maintenance/.codex-plugin/plugin.json
+++ b/package-maintenance/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-package-maintenance",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Maintain Pulumi provider repositories: run upgrade-provider and manage upstream Terraform patches",
   "skills": "./skills/",
   "author": {

--- a/package-maintenance/skills/upstream-patches/SKILL.md
+++ b/package-maintenance/skills/upstream-patches/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: upstream-patches
-description: Create, amend, remove, and rebase patches for Terraform provider submodules using `./scripts/upstream.sh`. Use when `upgrade-provider` or manual patch work needs owning-patch lookup, patch conflict fixes, patch/hunk removal, or upstream rebase.
+description: Evaluate, create, amend, remove, and rebase patches for Terraform provider submodules. Use when deciding whether a bridged Pulumi provider should carry an upstream change, designing or tracking a new patch, or handling owning-patch lookup, patch conflicts, patch/hunk removal, and upstream rebases.
 ---
 
 # Upstream Patches
@@ -9,8 +9,15 @@ description: Create, amend, remove, and rebase patches for Terraform provider su
 
 ## Default Behavior
 
+- Avoid creating a new patch when an upstream release, bridge or provider configuration, or a safe workaround can meet the need.
+- Do not create a new patch until the user or repository policy calls for one and the policy review below is complete.
 - If fixing a regression introduced by an existing patch, amend the owning patch commit.
-- Do not create a new patch unless the user explicitly asks.
+
+## Policy for New or Materially Changed Patches
+
+Before deciding, creating, or materially expanding a patch, read [the carried-patch policy](references/carrying-upstream-patches.md) completely. Also read repository-specific guidance for local tracking, tests, CI selection, and infrastructure safety.
+
+Do not load the policy reference for a purely mechanical rebase, removal, or amendment that does not change behavior, compatibility commitments, required evidence, or removal conditions.
 
 ## Commands Reference
 
@@ -126,7 +133,9 @@ git commit --amend --no-edit
 cd ..
 ```
 
-## Create New Patch (Only If Requested)
+## Create New Patch (After Policy Review)
+
+Before editing, confirm the owning layer, compatibility and state implications, regression evidence, tracking issue, and safe removal conditions required by the carried-patch policy and repository guidance.
 
 ```bash
 ./scripts/upstream.sh checkout

--- a/package-maintenance/skills/upstream-patches/references/carrying-upstream-patches.md
+++ b/package-maintenance/skills/upstream-patches/references/carrying-upstream-patches.md
@@ -1,0 +1,116 @@
+# Carrying Upstream Patches
+
+Use this policy before creating a new patch or materially changing the behavior or public commitment of an existing patch. Repository guidance supplies local commands, test paths, workflows, labels, and templates.
+
+## Avoid patches by default
+
+A carried patch adds recurring cost and risk to every upstream upgrade:
+
+- changes to the same upstream files can require a manual rebase;
+- a bad conflict resolution can introduce behavior that neither Pulumi nor upstream tested;
+- a patched property, resource, or behavior can become a public contract that Pulumi must maintain indefinitely;
+- upstream may later solve the same problem with an incompatible API or state representation;
+- cross-cutting patches can be difficult to test completely and difficult to remove safely.
+
+Prefer waiting for an acceptable upstream release, using bridge or provider configuration, or offering a documented workaround when those choices meet the user need. Severity may justify carrying a patch proactively, but urgency does not remove the compatibility and evidence requirements below.
+
+## Identify the owner
+
+Classify the behavior before designing the patch.
+
+### Upstream-owned behavior
+
+When the change fixes behavior in the upstream Terraform provider:
+
+- develop the correct solution in the upstream source, not directly in a generated patch file;
+- submit the change upstream in parallel with the Pulumi patch;
+- assess an existing upstream pull request rather than assuming it is safe to carry;
+- create a higher-quality upstream change when the existing proposal is incomplete;
+- carry the same change submitted upstream and explain any necessary differences.
+
+Do not weaken the upstream solution merely to make the Pulumi patch easier to remove.
+
+Every upstream-owned patch that changes resource behavior requires:
+
+1. An upstream acceptance test in the patch that reproduces the affected lifecycle or API behavior. Unit tests may supplement this test but do not replace it.
+2. Selection of that acceptance test in the Pulumi provider repository's targeted upstream-test CI.
+3. A Pulumi regression test that fails without the patch and passes with it.
+
+Assert the affected behavior directly. A successful deployment alone may not prove the regression.
+
+### Pulumi-specific behavior
+
+Some patches work around behavior owned by the bridge, a Pulumi provider, code generation, or the Pulumi engine. For these patches:
+
+- link the issue in the repository that owns the underlying problem;
+- explain why the change must be made in upstream provider code rather than bridge configuration or local provider code;
+- limit the patch to the incompatibility between Terraform and Pulumi behavior;
+- add a Pulumi regression test that fails without the patch;
+- add provider-upgrade coverage when the patch changes schema, diff, or state behavior consumed by existing Pulumi state;
+- state whether the divergence is temporary or intentionally permanent.
+
+Do not submit an upstream pull request for behavior that would be incorrect or irrelevant in Terraform.
+
+### Repository integration
+
+Some patches support Pulumi-specific integration such as a shim, provider identity, documentation generation, or repository build tooling.
+
+Prefer local provider configuration, documentation changes, or build orchestration when those can express the change. If upstream code is the only practical extension point, explain why in the tracking issue.
+
+Use validation specific to the integration. Do not add upstream acceptance or Pulumi lifecycle tests that cannot exercise the change.
+
+## Assess compatibility and maintenance risk
+
+Record known risks and unknowns in the tracking issue and patch pull request.
+
+### Public API changes
+
+If users adopt a property or resource added by a patch, Pulumi may have to support it even if upstream later chooses another name or design. Compare an upstream-owned patched API with the upstream submission. For Pulumi-specific behavior, state whether the divergence is an intentional permanent contract.
+
+Prefer patches that can be removed without changing Pulumi programs or state. Treat a patch that creates permanent surface area as an exceptional compatibility commitment, not a temporary backport.
+
+### State migrations
+
+Terraform records a schema version with resource state and selects state upgraders using that version. The bridge also records the Terraform schema version in Pulumi state.
+
+A migration that appears correct in Terraform may not be persisted by Pulumi. During a no-refresh `pulumi up`, the bridge can run the upgrader while computing the diff. If there is no diff, Pulumi does not call `Update`, so the upgraded state may not be written. A later deletion can therefore receive the old state. This behavior is tracked in [pulumi-terraform-bridge#3008](https://github.com/pulumi/pulumi-terraform-bridge/issues/3008).
+
+A downstream migration can also collide with upstream. If a patch adds a `0 → 1` migration, patched state may be marked version `1`. If upstream later releases a different `0 → 1` migration, that upgrader is not called for state already marked version `1`.
+
+Before carrying a state migration:
+
+- confirm that migration is required instead of making provider operations compatible with state written by released versions;
+- compare the schema version and migration with the upstream pull request when the behavior is upstream-owned;
+- explain how each expected replacement for the patch will consume state written by it;
+- add a Pulumi provider-upgrade test that creates state with a released provider and covers no-refresh update, refresh, and direct deletion;
+- preserve identifiers needed by later operations unless live lifecycle evidence proves a migration is necessary.
+
+### Cross-cutting changes
+
+If a patch changes shared code or multiple resources, name the affected resources and their test coverage. List behavior that remains untested. Do not infer broad safety from one representative resource without explaining why that resource exercises the shared behavior.
+
+## Track the patch lifecycle
+
+Every patch requires a provider-repository tracking issue containing:
+
+- why the patch is needed and which repository owns the underlying behavior;
+- links to the user-facing issue and owning upstream, bridge, codegen, or Pulumi issue;
+- the upstream pull request when the behavior is upstream-owned;
+- compatibility risks and unknowns;
+- exact regression test names and CI selection;
+- whether the patch is temporary or intentionally permanent;
+- observable removal conditions and the tests required to prove removal is safe.
+
+“Remove when fixed upstream” is not a sufficient removal condition. The issue must explain how to establish that the upstream replacement is compatible with Pulumi programs and state written while the patch was present.
+
+The patch pull request must link the tracking issue and relevant owner-side change, explain differences, and report exact test outcomes. Keep defined, selected, executed, asserted, skipped, and credential-blocked evidence distinct.
+
+## Stop conditions
+
+Stop and ask for maintainer judgment rather than silently proceeding when:
+
+- the patch introduces or renames public schema without a clear long-term compatibility decision;
+- the proposed patch differs materially from an unreviewed or incomplete upstream pull request;
+- a cross-cutting change lacks credible regression coverage;
+- required live infrastructure cannot be exercised safely;
+- ownership or safe removal conditions remain unclear.

--- a/package-maintenance/skills/upstream-patches/use_cases.yaml
+++ b/package-maintenance/skills/upstream-patches/use_cases.yaml
@@ -5,3 +5,5 @@ queries:
   - "Remove one hunk from an existing patches/*.patch file using scripts/upstream.sh"
   - "upgrade-provider left upstream on pulumi/patch-checkout during a conflict; help me preserve and check in the patch work"
   - "Create a new upstream patch for this bridged Pulumi provider"
+  - "Should this provider carry the proposed upstream Terraform PR, and what compatibility risks do we need to assess?"
+  - "Design the tracking issue, regression evidence, and removal conditions for this provider patch"


### PR DESCRIPTION
Bridged provider repositories share patch mechanics through `upstream-patches`, but the skill did not explain when carrying a patch is justified or what evidence makes one safe to maintain and eventually remove. That leaves each provider to rediscover compatibility, state, testing, and removal requirements during review.

This PR adds a progressively loaded carried-patch policy to `upstream-patches`. For new or materially changed patches, the skill now guides maintainers to:

- avoid a patch when an upstream release, local configuration, or safe workaround meets the need;
- identify whether behavior is owned upstream, by Pulumi, or by repository integration;
- assess public API, state migration, and cross-cutting maintenance risks;
- require owning-layer and Pulumi regression evidence appropriate to the change;
- record owner-side work, compatibility unknowns, and testable removal conditions;
- stop for maintainer judgment when compatibility or safe validation remains unclear.

Purely mechanical rebases, removals, and amendments do not load the policy reference unless they change behavior or compatibility commitments. Repository-specific CI workflow names, labels, test paths, and infrastructure safety rules remain in each provider repository rather than becoming assumptions in the shared skill.

The package-maintenance plugin version is bumped to `1.0.5`, and the routing cases now cover patch evaluation and lifecycle planning as well as patch mechanics.

Validation:

- `uv run pytest tests/test_manifests.py -v` — 10 passed
- `git diff --check`
