### PR TITLE
Add pulumi-migrate-from-discovered-stack migration skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Skills for converting and importing infrastructure from other tools to Pulumi:
 - **pulumi-cdk-to-pulumi**: Migrate AWS CDK applications to Pulumi
 - **cloudformation-to-pulumi**: Migrate AWS CloudFormation stacks/templates to Pulumi
 - **pulumi-arm-to-pulumi**: Migrate Azure ARM templates and Bicep to Pulumi
+- **pulumi-migrate-from-discovered-stack**: Migrate a CloudFormation or ARM stack that Pulumi Cloud's Discovery feature has already found, using the discovered-stacks API
 
 ### Pulumi Plugin (`pulumi/`)
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Convert and import infrastructure from other tools to Pulumi:
 | [pulumi-cdk-to-pulumi](migration/skills/pulumi-cdk-to-pulumi) | Migrate AWS CDK applications to Pulumi |
 | [cloudformation-to-pulumi](migration/skills/cloudformation-to-pulumi) | Migrate AWS CloudFormation stacks/templates to Pulumi |
 | [pulumi-arm-to-pulumi](migration/skills/pulumi-arm-to-pulumi) | Migrate Azure ARM templates and Bicep to Pulumi |
+| [pulumi-migrate-from-discovered-stack](migration/skills/pulumi-migrate-from-discovered-stack) | Migrate a CloudFormation or ARM stack that Pulumi Cloud's Discovery feature has already found, using the discovered-stacks API |
 
 ### Pulumi Skills
 
@@ -121,7 +122,7 @@ npx skills add pulumi/agent-skills --skill '*'
 Or install individual plugin groups:
 
 ```bash
-npx skills add pulumi/agent-skills/migration --skill '*'             # 4 migration skills
+npx skills add pulumi/agent-skills/migration --skill '*'             # 5 migration skills
 npx skills add pulumi/agent-skills/pulumi --skill '*'                # 7 pulumi skills (overview + specialized)
 npx skills add pulumi/agent-skills/delegation --skill '*'            # 1 delegation skill
 npx skills add pulumi/agent-skills/package-maintenance --skill '*'   # 2 package-maintenance skills

--- a/migration/skills/pulumi-migrate-from-discovered-stack/SKILL.md
+++ b/migration/skills/pulumi-migrate-from-discovered-stack/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: pulumi-migrate-from-discovered-stack
+description: |
+    Migrate a CloudFormation or ARM stack into a Pulumi stack, sourced from a
+    stack that Pulumi Cloud's Discovery feature has already found and exposed
+    via the discovered-stacks API. Load this skill when the user has a
+    discovered stack in Pulumi Cloud and wants to bring its resources under
+    Pulumi management. Do NOT load for greenfield Pulumi authoring, raw
+    template conversion with no discovered-stack counterpart (i.e. no matching
+    entry from the discovered-stacks API), or Terraform migration.
+---
+
+**Scope: this skill only applies to stacks Pulumi Cloud's Discovery feature has already scanned and exposed through the discovered-stacks API** (`GET .../discovered-stacks/{projectName}/{stackName}/resources`, see below). It is not for migrating an arbitrary CloudFormation/ARM template or account that Discovery hasn't scanned yet — if no discovered stack exists for the source, this skill has nothing to read and does not apply.
+
+> **Do not load `cloudformation-to-pulumi` or `pulumi-arm-to-pulumi` alongside this skill.** Those two skills prescribe a template-first workflow (mechanical translation → import) and mandate `aws-native` for AWS. This skill is cloud-state-first (import from discovered state → optional refactor against the template later) and defaults to `aws` classic / `azure-native`. The useful reference material from those two skills has been curated into [`cloudformation.md`](cloudformation.md) and [`arm.md`](arm.md) in this folder.
+
+---
+
+## Plan adjustment
+
+If you already generated a migration plan before loading this skill, review it against the workflow below and update it — the phases here supersede any earlier plan. Communicate the adjusted plan to the user before proceeding.
+
+## Success criteria
+
+A migration is complete when:
+
+1. **Complete resource coverage** — every discovered resource is imported OR has an annotation explaining why not.
+2. **Zero-diff** — `pulumi preview` shows no changes. This proves the code matches the cloud state exactly.
+3. **Progress tracked via the API** — use `compareTo` and migration annotations so progress is visible in Pulumi Cloud, not just in agent memory.
+4. **PR as the output** — a pull request with the migrated code and a migration report.
+
+## THE DISCOVERED-STACKS API
+
+### Fetching resources
+
+```
+GET /api/preview/insights/{orgName}/discovered-stacks/{projectName}/{stackName}/resources?compareTo={targetProject}/{targetStack}
+```
+
+Always include `compareTo` if the target Pulumi stack exists (it may already have state from a previous migration attempt). Returns a list of `DiscoveredResourceInfo` objects. **The JSON paths below are exact — verify before consuming:**
+
+-   `name` — top-level: logical name (CF Logical ID / ARM resource name). **Use this as the Pulumi resource name.**
+-   `originType` — top-level: native cloud type (e.g. `AWS::S3::Bucket`, `Microsoft.Storage/storageAccounts`)
+-   `providerType` — top-level: mapped Pulumi type token (e.g. `aws:s3/bucket:Bucket`). `null` if unmapped.
+-   `resource.inputs.providerId` — physical cloud ID for `pulumi import`.
+-   `resource.urn` — the URN to use as `resourceUrn` in annotation requests (copy verbatim).
+-   `migrationStatus` — top-level: one of the statuses below.
+-   `annotation` — top-level: user/agent annotation if one exists (see Annotations below).
+
+The `resource.inputs` object also carries raw cloud-provider data:
+
+**For CloudFormation** — `resource.inputs.cloudFormation`:
+
+-   `physicalResourceId` — the original CF physical ID
+-   `resourceType` — the CF type (e.g. `AWS::IAM::Role`)
+-   `resourceStatus` — e.g. `CREATE_COMPLETE`, `DELETE_COMPLETE`
+-   `driftStatus` — `NOT_CHECKED`, `IN_SYNC`, `DRIFTED`
+
+For CDK-synthesized CF stacks, `inputs.cdkPath` is also present — see [`cloudformation.md §5`](cloudformation.md) for how to use it.
+
+**For ARM** — `resource.inputs.arm`:
+
+-   `properties.targetResource.id` — the full Azure resource ID
+-   `properties.targetResource.resourceType` — the ARM type
+-   `properties.targetResource.resourceName` — the ARM resource name
+-   `properties.provisioningState` — e.g. `Succeeded`
+
+### Migration statuses
+
+Statuses are PascalCase. First match wins:
+
+1. **`Migrated`** — the resource was found in the `compareTo` Pulumi stack. Already under Pulumi management; skip.
+2. **`Ready`** — `providerType` and `providerId` are set and the scanner confirmed the resource exists. Import with `pulumi import <providerType> <name> <providerId> --generate-code --out <file>.ts` (NEVER without `--generate-code --out` — see Phase 4).
+3. **`NotFound`** — `providerType` and `providerId` are set, but the scanner could not confirm the resource's current state. May be deleted, mapping may be imperfect, or scanner hit a gap. Verify before importing.
+4. **`NotApplicable`** — container or wrapper types (`AWS::CloudFormation::Stack`, `Microsoft.Resources/deployments`, `pulumi:providers:*`) are not individually migratable. Skip silently.
+5. **`NoMatch`** — `providerType` is `null`. No mapping found. Common examples:
+    - CF Custom Resources (e.g. `Custom::VpcRestrictDefaultSG`) — no direct Pulumi equivalent.
+    - Inline policies — `AWS::IAM::Policy` modeled as an inline property of `aws:iam/role:Role`. Once the parent Role is migrated, annotate the policy as migrated.
+6. **`PulumiOnly`** — exists in the `compareTo` stack with no discovered counterpart, or those created to migrate NoMatch resources. Surface to user.
+
+Resources with `annotation.statusOverride` should be treated as resolved per the override, even if the computed status disagrees.
+
+### Annotations
+
+```
+PUT  /api/preview/insights/{orgName}/discovered-stacks/{projectName}/{stackName}/migration
+DELETE /api/preview/insights/{orgName}/discovered-stacks/{projectName}/{stackName}/migration?resourceUrn={urn}
+```
+
+PUT body:
+
+```json
+{
+  "resourceUrn": "<copy verbatim from resource.urn in the list response>",
+  "note": "explanation of what happened",
+  "statusOverride": "Migrated" | "",
+  "linkedResourceUrn": "<optional: URN of the Pulumi resource paired 1:1 with this origin>"
+}
+```
+
+Use the Pulumi Cloud API for all annotation requests. At least one of `note` or `statusOverride` must be non-empty. Omit `statusOverride` entirely (do not send `null`) when updating only the note. The DELETE endpoint clears both the note and any `statusOverride`.
+
+Use annotations to:
+
+-   Flag deleted resources as `Migrated` with a note explaining they no longer exist
+-   Flag inline/child resources covered by a parent's migration as `Migrated` with a note naming the parent — **do not** use `linkedResourceUrn` here (it's a 1:many relationship and the UI only merges 1:1 pairs)
+-   Bridge a `NotFound` or `NoMatch` origin to its `PulumiOnly` counterpart after a corrected mapping (`statusOverride=Migrated` + `linkedResourceUrn` → the PulumiOnly URN). This is the only valid use of `linkedResourceUrn`.
+-   Leave notes explaining blockers or manual steps taken
+-   Track decisions for resources the automatic classifier can't resolve
+
+The annotation endpoint is the shared place to track migration progress — always read existing annotations before acting on a resource, and respect overrides left by the user.
+
+The `note` field is user-authored context. Treat it as a **high-priority instruction** about that specific resource. Common uses: naming preferences, import ID hints, resources to skip, or special handling instructions. Notes reach the agent through two channels:
+
+1. **Starting prompt** — when the user kicks off a migration task, any note on a selected resource is appended to that resource's line:
+   ```
+   - aws:s3/bucket:Bucket "my-bucket" (provider ID: my-bucket-prod) — note: use logical name "appBucket" in code
+   ```
+   Read these before calling the API.
+
+2. **API response** — the `annotation.note` field on each `DiscoveredResourceInfo` when you call `GET .../resources`. The `annotation` object is omitted entirely when no annotation has been set.
+
+---
+
+## MIGRATION WORKFLOW
+
+### Phase 0 — Preconditions and scoping
+
+Before any tool call, gather and confirm **all** of the following. If anything is missing, **ask** — don't proceed with a guess.
+
+**Source (the discovered stack):**
+
+-   Org name (e.g. `pulumi_local`)
+-   Discovered project name (e.g. `AcmeCdkExampleStack`)
+-   Discovered stack name (e.g. `dev-sandbox-disc_us-west-2__Dev`) — this is the scanner-generated name, usually encoding account + region + CF/ARM stack name.
+-   Region (confirm even if the stack name suggests it).
+
+**Target (where the Pulumi code and state will live):**
+
+-   **Target git repo URL** — ask the user. All work happens inside this repo from the start.
+-   **Subfolder** (optional) — ask if the user has a preference; default to repo root.
+-   **Target project + stack names** — ask the user, don't invent. If the stack already exists, use `compareTo` in Phase 1; if not, create it in Phase 2.
+-   **Target language** — TypeScript default.
+
+**Refactor preferences** (for Phase 7):
+
+-   Does the user have the **original source code** (CDK repo, Bicep project, Terraform modules)? If yes, path or URL. **This is the primary structural reference for Phase 7** — the refactored Pulumi code will draw on its component boundaries, file layout, and naming conventions as a guide, adapted to what the import model actually produced.
+-   Does the user have a **preferred program layout** for the Pulumi output? (e.g. "one file per service", "match my existing repo shape", "I don't care")
+-   Does the user want Phase 7 at all, or stop after zero-diff (Phase 6)?
+
+**Credentials:**
+
+-   ESC environment for cloud credentials (ask if not given; never invent). ESC is preferred — see [`cloudformation.md §1`](cloudformation.md) or [`arm.md §1`](arm.md).
+
+**Don't start Phase 1 until all of the above are confirmed.** Summarize the plan back to the user and wait for approval.
+
+### Phase 1 — Resource fetch and triage
+
+Start here every time, even when resuming an existing migration. The API + any existing annotations are the source of truth for what's been done so far. If the target repo already has Pulumi code, read it — it tells you the conventions, existing resources, and how far a previous attempt got.
+
+1. Fetch discovered resources: `GET .../discovered-stacks/{projectName}/{stackName}/resources`.
+    - **Target stack exists** (resumed migration): append `?compareTo=<targetProject>/<targetStack>`.
+    - **Target stack does not exist** (greenfield): **omit `compareTo`** — the API returns 404 if the target stack isn't found. After Phase 2 creates the stack, subsequent calls can include it.
+2. **Save the response to disk** — `./.migration/resources-baseline.json`.
+3. **Run triage**: `python3 <skill-base-dir>/scripts/triage.py .migration/resources-baseline.json` — prints status counts (accounting for annotation overrides) and a per-resource table.
+4. Present the plan to the user:
+    > "Found N resources. A already Migrated, M Ready, K NotFound, J NoMatch, L non-migratable containers. I'll import Ready first, then verify NotFound, then triage NoMatch with you. Sound good?"
+
+Get confirmation before writing any code.
+
+### Phase 2 — Target repo and Pulumi stack setup
+
+1. **Clone the target git repo** (from Phase 0) and work inside it for all subsequent phases. If the repo already has code, read it to understand existing conventions and resources before adding new ones.
+2. If the target stack already exists (Phase 0 check), select it. Otherwise:
+    - Create the Pulumi project: `pulumi new <language> --name <project> --stack <org>/<project>/<stack> --yes`.
+3. Set provider config: `pulumi config set aws:region <r>` (or `azure-native:location`).
+4. Link the ESC environment if provided.
+
+**No empty `pulumi up` needed.**
+
+> Concrete commands for project + stack setup, region config, and provider install: [`cloudformation.md §2`](cloudformation.md) or [`arm.md §2`](arm.md).
+
+### Phase 3 — Build the import file
+
+Generate the import file: `python3 <skill-base-dir>/scripts/build_import.py .migration/resources-baseline.json .migration/import.json`. This filters Ready/NotFound resources (excluding already-annotated ones) and maps API fields to the Pulumi import format (`type` ← providerType, `name` ← name, `id` ← resource.inputs.providerId).
+
+### Phase 4 — Import
+
+Using the `import.json` from Phase 3.
+
+**Always use `--generate-code --out`** — without it, resources land in state with no code, breaking `pulumi preview`.
+
+```
+pulumi import --file import.json --generate-code --out batch.<ext>
+# then: append generated code into the main program file and delete the batch file
+```
+
+**Per-batch loop: import → preview → commit → annotate.** Aim for ~20 resources per batch. For CDK stacks, batch by `cdkPath` top-level group; otherwise batch by resource type prefix.
+
+1. **Import** the batch.
+2. **`pulumi preview`** — zero diff required. Fix any diffs before moving on.
+3. **Commit** the program changes to a branch.
+4. **Annotate** each imported resource — `PUT .../migration` with note and **no `statusOverride`**. Annotations survive context resets and are visible in the UI.
+
+`?compareTo` is a **live progress signal** — `pulumi import` writes state immediately, so `migrationStatus` flips to `Migrated` after each import. **Do not run `pulumi up`** (see Phase 6).
+
+**Reserve `statusOverride`** for cases where the computed status will be wrong:
+
+-   `statusOverride=Migrated` (with `linkedResourceUrn`) — resource covered by another (inline IAM policy → parent Role, IGW attachment → IGW, etc.).
+-   `statusOverride=Migrated` (with a note, no `linkedResourceUrn`) — resource is deleted, dangling, or has no Pulumi equivalent. Flag it resolved so it drops out of the outstanding work.
+
+### Phase 5 — NotFound and NoMatch triage
+
+**Default strategy: try first, annotate second.** For both NotFound and corrected-mapping cases, attempting `pulumi import` is the fastest way to learn what's actually wrong. The error messages are precise and actionable.
+
+**NotFound** (`providerType` set, state unconfirmed):
+
+Common outcomes:
+
+1. **Resource is deleted.** `pulumi import` returns `Preview failed: resource '<id>' does not exist`. Annotate `statusOverride=Migrated` with the literal error in the note. **Don't retry.** In practice, a substantial share of NotFound resources turn out to be deleted rather than a mapping error.
+
+2. **Wrong `providerType` mapping.** Import fails with a type-validation error or schema mismatch. Several CF types have multiple valid Pulumi mappings (VPC gateway attachment / VPN vs IGW; S3 vs s3control; RDS instance vs cluster instance; SES v2 vs v1; etc.) — our scanner picks a primary that doesn't always match your resource. **Look up the `originType` in [`cloudformation.md §7`](cloudformation.md)**, override `providerType` in the import file, retry. Then handle the fingerprint side-effect (next bullet).
+
+3. **Wrong-mapping side-effect: PulumiOnly appears.** When the agent imports with a corrected `providerType`, fingerprint matching against the discovered resource fails. The discovered resource stays `NotFound` (or `NoMatch`) and a new `PulumiOnly` entry appears. **Annotate the original origin row as `statusOverride=Migrated` with `linkedResourceUrn` pointing to the PulumiOnly URN.** This bridges them in the UI and keeps the bookkeeping clean.
+
+4. **Resource is alive and mapping is correct.** Import succeeds. Status flips to `Migrated` automatically.
+
+**NoMatch** (`providerType` is `null`):
+
+Common patterns:
+
+1. **Inline IAM policies.** `AWS::IAM::Policy` whose name matches a migrated Role's prefix is an inline policy already captured as `inlinePolicies` on the Role's import. Annotate `statusOverride=Migrated` with note: `"inline policy of <RoleName>"`.
+
+2. **AWS::SecretsManager::SecretTargetAttachment** has no direct Pulumi mapping. The link between secret and target (RDS cluster, etc.) is implicit via the cluster's credentials config. Annotate `statusOverride=Migrated` with a note explaining the implicit link.
+
+3. **CDK Custom Resources** (`Custom::*`). Typically a Lambda handler doing the actual work. Check [`cloudformation.md §5`](cloudformation.md) for known handler → Pulumi replacement mappings. **Don't annotate `Migrated` without confirming with the user** — surface what the handler does and let them decide.
+
+4. **Other NoMatch types.** Look up the `originType` in the cloud provider docs (CF resource type reference or ARM resource type reference) to understand what the resource is, then search the Pulumi registry for a matching provider type. If the mapping is ambiguous, surface to the user and ask.
+
+**Pre-existing PulumiOnly entries.** Beyond the corrected-mapping artifacts above, `PulumiOnly` also covers resources already in the target stack that aren't part of this migration. Leave those as-is — no annotation needed.
+
+> For cloud-specific lookup commands (verifying resources exist, finding import IDs, querying the cloud), provider-choice rules (`aws` classic vs `aws-native`, `azure-native` vs `azure`), the Preview Resolution Workflow, and known import quirks, see [`cloudformation.md §3–§6`](cloudformation.md) or [`arm.md §3–§6`](arm.md).
+
+### Phase 6 — Reconciliation & PR
+
+1. Run `pulumi preview` — **confirm there are NO changes**. Any diff means the generated code doesn't match the imported state. Diffs come in three shapes:
+    - **Removed (`-`)** — a field the cloud has but your code doesn't set. **Add it to the code** with the real cloud value. Don't `ignoreChanges`.
+    - **Added (`+`)** — a field your code sets that the provider didn't return. If computed/read-only → `ignoreChanges`. If a provider default re-statement → remove from code.
+    - **Changed (`~`)** — value mismatch. Query the cloud, determine the correct value, update code. Never silence with `ignoreChanges`.
+
+    Expect 2–5 preview rounds for complex resources. **Never run `pulumi up` to resolve diffs — that modifies the cloud, not the code.** See [`cloudformation.md §6`](cloudformation.md) or [`arm.md §6`](arm.md) for cloud-specific diff patterns.
+2. Do one final `GET resources?compareTo=...` and verify the expected distribution (this reflects the current backend state — `migrationStatus` is already up-to-date since every `pulumi import` writes state):
+    - `Migrated` — all imported resources
+    - `PulumiOnly` — Pulumi-only resources, including any corrected-mapping imports linked via annotation
+    - `NoMatch` remaining — every one should have an annotation
+    - `NotApplicable` (containers) — silently skipped
+3. Proceed to Phase 7 (refactor offer) **before** opening the PR.
+
+The migration is functionally complete when preview is clean and the API triage shows no unresolved resources. **Do not run `pulumi up`.** The imported state is already synced to Pulumi Cloud via `pulumi import`; there's nothing for `pulumi up` to do that serves the migration.
+
+---
+
+### Phase 7 — Refactor and maintainability review (before the PR)
+
+Zero-diff is achieved, but the imported code is "flat" — hardcoded values, no cross-resource references, all resources at the top level. **Before opening the PR**, offer the user a readability refactor.
+
+**7a — Offer and orient**
+
+If Phase 0 didn't capture explicit refactor preferences, or the user hasn't explicitly declined, **ask now**:
+
+> "Preview is clean and all resources are accounted for. Before I open the PR, I'd like to refactor the code for maintainability — replacing any hardcoding with cross-resource references, extracting config parameters, and grouping related resources. (If you gave me a source repo, I'll use it as the structural blueprint, matching the intended file layout and component names.) Want me to go ahead?"
+
+If they decline, skip to Phase 8.
+
+**7b — Implement the refactor**
+
+Read [`refactor.md`](refactor.md) for strategies, invariants, and template-reading references. Key priorities in order:
+
+1. **Take structural cues from the source repo first** — if the user provided a source repo, read it now (clone or use the local path from Phase 0). Use its file layout, component/module boundaries, and naming conventions as a guide. Where a group of resources maps naturally to a class, module, or subdirectory in the source and that grouping still feels natural for the imported Pulumi program, mirror that structure; otherwise avoid forcing artificial groupings just to match the source mechanically.
+2. **Replace literal ARN/ID references** with cross-resource output references.
+3. **Extract config parameters** (region, account ID, environment tag).
+4. **Consolidate into `ComponentResource` classes** where the source repo or CDK paths suggest a natural grouping.
+5. **Split into files** only last — and only when a natural isle warrants it.
+
+Run `pulumi preview` after every non-trivial change. Zero-diff must hold throughout. If preview shows a diff, revert that single change before trying anything else — see [`refactor.md` § The invariant](refactor.md) for recovery steps.
+
+**7c — User walkthrough and maintainability sign-off**
+
+After the refactor, **present the result to the user before opening the PR**:
+
+1. Show a summary of what changed: files created/renamed, components introduced, literals replaced, config keys added.
+2. Walk through the top-level `index.ts` (or equivalent) line by line if it's under ~80 lines; otherwise describe the module breakdown.
+3. Highlight any judgment calls (e.g. "I grouped the IAM resources into `iam.ts` to match the `lib/iam/` directory in your source repo — let me know if you'd prefer a different name").
+4. Ask explicitly: **"Does this structure match how you'd expect to maintain this code?"** Wait for the user's answer. If they request changes, make them (always preview after) and repeat the walkthrough until they're satisfied.
+
+Only proceed to Phase 8 once the user confirms the structure is acceptable.
+
+---
+
+### Phase 8 — PR and migration report
+
+Produce the migration report (see below) and open the PR. The PR includes whatever state the code is in — raw imported code (if the user skipped Phase 7) or the refactored version (if they opted in).
+
+---
+
+## MIGRATION REPORT FORMAT
+
+Include in the PR description:
+
+1. **Overview** — source discovered stack → target Pulumi stack, region, language.
+2. **Triage summary** — counts by status at start and end.
+3. **Resource mapping table** — name, origin type, provider type, status, notes.
+4. **Gaps** — unmapped resources and why, with annotations.
+5. **Progress URL** — link to the discovered-stacks comparison endpoint for ongoing tracking.
+6. **Next steps** — pending user decisions, optional refactoring.

--- a/migration/skills/pulumi-migrate-from-discovered-stack/agents/openai.yaml
+++ b/migration/skills/pulumi-migrate-from-discovered-stack/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Discovered Stack to Pulumi Migration"
+  short_description: "Migrate a Pulumi Cloud discovered CloudFormation or ARM stack to Pulumi"
+  default_prompt: "Use $pulumi-migrate-from-discovered-stack to migrate a stack discovered by Pulumi Cloud's Discovery feature into a managed Pulumi stack."

--- a/migration/skills/pulumi-migrate-from-discovered-stack/arm.md
+++ b/migration/skills/pulumi-migrate-from-discovered-stack/arm.md
@@ -1,0 +1,288 @@
+# ARM / Azure Reference
+
+Reference material for the `pulumi-migrate-from-discovered-stack` skill when working with ARM (or Bicep-derived) discovered stacks. Use this file for:
+
+- Azure credentials and CLI setup (Phase 0 / 2)
+- Looking up resource details, verifying existence, finding import IDs (Phase 4 / 5 troubleshooting)
+- Provider choice (`azure-native` vs `azure` classic)
+- Azure-specific import patterns (child resources, lower-cased IDs)
+- The **Preview Resolution Workflow** (§6) — applies to both ARM and CF imports when `pulumi preview` shows a diff after import
+- Reading the original ARM template during the optional refactor phase
+
+> **Important:** this is reference, **not a workflow**. The main `SKILL.md` (Phase 0–6) is the workflow. The public `pulumi-arm-to-pulumi` skill prescribes a template-first, mechanical-translation approach — that conflicts with our cloud-state-first import flow. Do not load it alongside this skill.
+
+---
+
+## 1. Azure credentials
+
+Federated-token login via ESC (most Azure ESC environments ship an OIDC token):
+
+```bash
+pulumi env run {org}/{project}/{environment} -- bash -c '
+  az login --service-principal \
+    -u "$ARM_CLIENT_ID" \
+    --tenant "$ARM_TENANT_ID" \
+    --federated-token "$ARM_OIDC_TOKEN"'
+```
+
+Sanity-check credentials before running imports:
+
+```bash
+az account show
+az account list --query "[].{Name:name, SubscriptionId:id, IsDefault:isDefault}" -o table
+```
+
+---
+
+## 2. Azure-specific project setup
+
+After creating the Pulumi project (see SKILL.md Phase 2):
+
+```bash
+# Location config — set BOTH if you'll mix azure and azure-native resources
+pulumi config set azure-native:location <location>
+pulumi config set azure:location <location>
+
+# Install providers
+npm install @pulumi/azure-native @pulumi/azure
+```
+
+---
+
+## 3. Querying ARM and Azure resources
+
+These help during Phase 5 (NotFound / NoMatch triage) when you need to verify a resource exists or look up an ID our API didn't already capture, and during Phase 7 (optional refactor) to fetch the original template as a structural reference.
+
+### Export the ARM template for a resource group
+```bash
+az group export --name <rg> --output json > .migration/template.json
+```
+
+Used in Phase 7 as a refactor reference (component grouping, parameters, conditional logic). Azure reconstructs the template from live resource state, so `skipAllParameterization: false` is the default — you get parameterized output. For Bicep source when the user has it, ask for the repo instead; Bicep is richer than the exported template.
+
+### List all resources in a resource group
+```bash
+az resource list --resource-group <rg> --output json
+```
+
+### Show a single resource by ID
+```bash
+az resource show --ids <resource-id> --output json
+az resource show --ids <resource-id> --query "{name:name, location:location, properties:properties}" --output json
+```
+
+### Targeted service lookups
+
+The generic `az resource show` sometimes hides service-specific details. Use `az <service> show --name <name> --resource-group <rg>` instead (e.g. `az storage account show`, `az webapp show`, `az network vnet show`, `az keyvault show`).
+
+### Azure Resource ID format
+
+Azure Resource IDs follow a predictable pattern. Most `pulumi import` IDs for `azure-native` use this form verbatim:
+
+```
+/subscriptions/{sub}/resourceGroups/{rg}/providers/{ns}/{type}/{name}
+```
+
+Child resources extend it:
+
+```
+.../Microsoft.Web/sites/{site}/config/appsettings
+.../Microsoft.Network/networkSecurityGroups/{nsg}/securityRules/{rule}
+.../Microsoft.ApiManagement/service/{svc}/apis/{api}/operations/{op}/policies/policy
+```
+
+Our API returns the full ID at `resource.inputs.arm.properties.targetResource.id` (or `resource.inputs.providerId`). Use that verbatim in the import file; don't reconstruct it by hand.
+
+### Listing by type
+```bash
+az resource list --resource-type "Microsoft.Storage/storageAccounts" --output json
+```
+
+Useful when our API returns `NoMatch` and you want to see what else in the subscription looks similar.
+
+---
+
+## 4. Provider choice — `azure-native` vs `azure` (classic)
+
+**Default to `azure-native`.** It maps 1:1 with ARM resource types (e.g. `Microsoft.Storage/storageAccounts` → `azure-native:storage:StorageAccount`), which is what our discovery service uses.
+
+**Use `azure` (classic) when:**
+- `azure-native` doesn't expose a feature you need.
+- The classic resource is significantly simpler for a one-off (e.g. classic has some convenience abstractions for App Service + Plan).
+- The user has existing classic-based code in the target stack and you're matching conventions.
+
+**Don't mix providers within a resource group.** Pick one provider per logical cluster of resources; mixing leads to cross-provider dependency issues and harder zero-diff.
+
+### TypeScript output handling for `azure-native`
+
+Same pattern as `aws-native` — outputs often include `undefined`. Avoid `!` non-null assertions; use `.apply()`:
+
+```ts
+// WRONG
+connectionString: account.primaryConnectionString!,
+
+// CORRECT
+connectionString: account.primaryConnectionString.apply(s => s || ""),
+```
+
+### Lower-cased IDs
+
+`azure-native` normalizes Azure resource IDs to lowercase internally. If the original ARM template used PascalCase (e.g. `/resourceGroups/MyRG/...`), fingerprint matching against our discovery service may fail even after a clean import — the two records encode the same resource but don't fingerprint-match. Handle via annotation + `linkedResourceUrn` (see SKILL.md Phase 5).
+
+---
+
+## 5. Child resource patterns (Azure-specific)
+
+Many ARM resources decompose into multiple Pulumi resources:
+
+| ARM | Pulumi |
+|---|---|
+| `Microsoft.Web/sites` | `azure-native:web:WebApp` |
+| `Microsoft.Web/sites/config` (appsettings) | `azure-native:web:WebAppApplicationSettings` with ID ending `/config/appsettings` |
+| `Microsoft.Web/sites/config` (auth) | `azure-native:web:WebAppAuthSettings` |
+| `Microsoft.Web/sites/config` (connectionStrings) | `azure-native:web:WebAppConnectionStrings` |
+| `Microsoft.Network/networkSecurityGroups/securityRules` | `azure-native:network:SecurityRule` (separate from the NSG) |
+| `Microsoft.ApiManagement/service/apis/operations/policies` | `azure-native:apimanagement:ApiOperationPolicy` |
+
+The discovered API surfaces these as separate `Ready` / `NotFound` entries. The agent must expect them and import each as a standalone resource with its full child-resource ID.
+
+Example import entries:
+
+```json
+{"type": "azure-native:web:WebApp",
+ "name": "MyWebApp",
+ "id": "/subscriptions/.../resourceGroups/rg/providers/Microsoft.Web/sites/mywebapp"},
+{"type": "azure-native:web:WebAppApplicationSettings",
+ "name": "MyWebAppSettings",
+ "id": "/subscriptions/.../resourceGroups/rg/providers/Microsoft.Web/sites/mywebapp/config/appsettings"}
+```
+
+---
+
+## 6. Common Azure diff patterns
+
+The generic removed/added/changed diagnostic workflow is in SKILL.md Phase 6. Below are Azure-specific patterns:
+
+| Resource | Property | Resolution |
+|---|---|---|
+| `StorageAccount` | `networkRuleSet` | Add to code with values from `az storage account show` |
+| `StorageAccount` | `encryption.services` | Cloud default; explicit add |
+| `StorageAccount` | `primaryEndpoints` | Computed/read-only → `ignoreChanges` |
+| `WebApp` | `siteConfig.appSettings` | Often lives in a separate `WebAppApplicationSettings` child resource |
+| `WebApp` | `kind` | Must match exact cloud value ("app", "functionapp", "linux", etc.) |
+| `VirtualNetwork` | `subnets` | Usually better as separate `Subnet` resources than inline |
+| `NetworkSecurityGroup` | `securityRules` | Prefer separate `SecurityRule` resources; inline rules cause diffs |
+
+### Debug command
+
+```bash
+pulumi preview --diff --show-config --show-secrets
+```
+
+---
+
+## 7. Reading an ARM template (refactor phase only)
+
+After Phase 6 (zero-diff achieved, PR created), if the user wants the imported program to *look* like the original ARM/Bicep (parameterization, variables, copy loops, conditionals, components), the template is the reference. **This is optional polish, not part of the migration itself.** Re-run `pulumi preview` after each refactor change; any new diff means the refactor introduced drift.
+
+### ARM Parameters → Pulumi config
+
+```ts
+// ARM: "parameters": {"location": {"type": "string", "defaultValue": "eastus"}}
+const config = new pulumi.Config();
+const location = config.get("location") || "eastus";
+const replicas = config.getNumber("replicas") || 3;
+const enabled = config.getBoolean("enabled") ?? true;
+const password = config.requireSecret("adminPassword");
+```
+
+### ARM Variables → Pulumi constants
+
+```ts
+// ARM: "variables": {"storageSku": "Standard_LRS"}
+const storageSku = "Standard_LRS";
+```
+
+ARM's `uniqueString()` is *not* cryptographically equivalent to anything in Pulumi. If you need a deterministic suffix, use a truncated hash of the stack name or a `random.RandomString` resource with a fixed seed.
+
+### ARM `copy` loops → JS loops
+
+```ts
+// ARM: "copy": {"name": "subnetLoop", "count": 3}
+for (let i = 0; i < 3; i++) {
+  new azure_native.network.Subnet(`subnet-${i}`, { ... });
+}
+```
+
+### ARM `condition` → JS conditionals
+
+```ts
+// ARM: "condition": "[equals(parameters('env'), 'prod')]"
+if (env === "prod") {
+  new azure_native.monitor.DiagnosticSetting(...);
+}
+```
+
+### ARM `dependsOn` → Pulumi dependencies
+
+- **Prefer implicit**: reference the other resource's output (`subnet.id`) in the dependent resource's inputs. Pulumi tracks the dependency automatically.
+- **Explicit** `dependsOn: [...]` resource option only when there's no property-level reference but ordering still matters.
+
+### ARM intrinsic functions → Pulumi equivalents
+
+| ARM | Pulumi |
+|---|---|
+| `resourceId('Microsoft.Storage/...', name)` | resource output (`account.id`) |
+| `reference(resource)` | resource output object |
+| `concat(a, '/', b)` | template literal or `pulumi.interpolate` |
+| `format('{0}-{1}', a, b)` | template literal |
+| `parameters('x')` | `config.get("x")` |
+| `variables('x')` | local const |
+| `resourceGroup().location` | `resourceGroup.location` |
+| `subscription().subscriptionId` | `azure.core.getClientConfig().subscriptionId` |
+| `uniqueString(...)` | deterministic hash, or accept non-determinism |
+| `if(cond, a, b)` | `cond ? a : b` |
+
+### Nested templates → Pulumi Component Resources
+
+An ARM nested template (linked template) typically maps to a Pulumi `ComponentResource`:
+
+```ts
+class NetworkComponent extends pulumi.ComponentResource {
+  public readonly vnet: azure_native.network.VirtualNetwork;
+  public readonly subnets: azure_native.network.Subnet[];
+
+  constructor(name: string, args: NetworkArgs, opts?: pulumi.ComponentResourceOptions) {
+    super("custom:network:NetworkComponent", name, {}, opts);
+    this.vnet = new azure_native.network.VirtualNetwork(`${name}-vnet`, {...}, {parent: this});
+    this.subnets = args.subnets.map((s, i) =>
+      new azure_native.network.Subnet(`${name}-subnet-${i}`, {...}, {parent: this}));
+    this.registerOutputs({vnet: this.vnet, subnets: this.subnets});
+  }
+}
+```
+
+### ARM Outputs → Pulumi exports
+
+```ts
+// ARM: "outputs": {"vnetId": {"type": "string", "value": "[reference(...).id]"}}
+export const vnetId = vnet.id;
+```
+
+### Common pitfalls
+
+- Missing `.apply()` on Output types — TypeScript errors or string-vs-Output confusion.
+- Confusing Pulumi resource *name* (logical) with ARM resource `name` (the storage account's actual name, the VM's hostname, etc.). Both are required and different.
+- Assuming ARM property names match Pulumi (`accountName` vs `name`, `skuName` vs `sku.name`, etc.) — always check the Pulumi schema.
+- Forgetting to translate `concat()` / `format()` / `uniqueString()` — these are runtime ARM functions, not constants.
+
+---
+
+## 8. Further reading
+
+- [Pulumi Azure Native provider](https://www.pulumi.com/registry/packages/azure-native/)
+- [Pulumi Azure (classic) provider](https://www.pulumi.com/registry/packages/azure/)
+- [Migrating to Pulumi from ARM](https://www.pulumi.com/docs/iac/adopting-pulumi/migrating-to-pulumi/from-arm/)
+- [ARM template syntax](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/syntax)
+- [ARM template functions](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource)
+- [Azure CLI docs](https://learn.microsoft.com/en-us/cli/azure/)

--- a/migration/skills/pulumi-migrate-from-discovered-stack/cloudformation.md
+++ b/migration/skills/pulumi-migrate-from-discovered-stack/cloudformation.md
@@ -1,0 +1,232 @@
+# CloudFormation Reference
+
+Reference material for the `pulumi-migrate-from-discovered-stack` skill when working with CloudFormation (or CDK-synthesized CF) discovered stacks. Use this file for:
+
+- AWS credentials and CLI setup (Phase 0 / 2)
+- Looking up resource details, verifying existence, finding import IDs (Phase 4 / 5 troubleshooting)
+- Provider choice (`aws` classic vs `aws-native`)
+- Custom resource handler replacements (CDK-synthesized stacks)
+- Reading the original CF template during the optional refactor phase
+
+> **Important:** this is reference, **not a workflow**. The main `SKILL.md` (Phase 0–6) is the workflow. The public `cloudformation-to-pulumi` skill prescribes a template-first, `aws-native`-mandatory approach driven by `cdk-importer` — that conflicts with our cloud-state-first import flow. Do not load it alongside this skill.
+
+---
+
+## 1. AWS credentials
+
+Sanity-check credentials before running imports:
+
+```bash
+aws sts get-caller-identity   # confirm credentials are alive and identify the account
+aws configure get region      # confirm region matches the discovered stack
+```
+
+STS session tokens expire in 1–12 h — if `pulumi import` fails with `ExpiredToken`, ask for fresh creds.
+
+---
+
+## 2. AWS-specific project setup
+
+After creating the Pulumi project (see SKILL.md Phase 2):
+
+```bash
+pulumi config set aws:region <region>
+# If using aws-native provider, also set aws-native:region
+
+npm install @pulumi/aws
+```
+
+---
+
+## 3. Querying CloudFormation and AWS
+
+These help during Phase 5 (NotFound / NoMatch triage) when you need to verify a resource exists or look up an ID our API didn't already capture, and during Phase 7 (optional refactor) to fetch the original template as a structural reference.
+
+### Get the original CF template
+```bash
+aws cloudformation get-template \
+  --region <region> \
+  --stack-name <cfn-stack-name> \
+  --query 'TemplateBody' \
+  --output json > .migration/template.json
+```
+
+Two uses:
+- **Phase 5 triage**: when `NoMatch`, see what a resource was *supposed* to be (original type, properties, relationships).
+- **Phase 7 refactor**: a concrete reference for resource grouping, parameters, conditional logic, intrinsic-function references. Save it in `.migration/` so it's committed alongside the code.
+
+### Verify a single resource
+```bash
+aws cloudformation describe-stack-resource \
+  --region <region> \
+  --stack-name <cfn-stack-name> \
+  --logical-resource-id <id>
+```
+
+If this returns `ResourceStatus: DELETE_COMPLETE` or 404, the resource is gone — annotate `statusOverride=Migrated` with a note.
+
+### General AWS lookup
+
+For composite-ID resources (e.g. `aws:lambda/permission:Permission`) or when our API doesn't have the details, use AWS Cloud Control:
+
+```bash
+aws cloudcontrol get-resource --type-name <CFN-type> --identifier <id>
+aws cloudcontrol list-resources --type-name <CFN-type>
+```
+
+Works for any CloudFormation resource type. For the Pulumi type's expected import-ID shape, check the resource's registry page at https://www.pulumi.com/registry/packages/aws/api-docs/ (the "Import" section is on each resource page).
+
+---
+
+## 4. Provider choice — `aws` (classic) vs `aws-native`
+
+**Default to `aws` (classic)** for our flow. The discovered-stacks API maps most CF types to classic provider tokens (e.g. `AWS::S3::Bucket` → `aws:s3/bucket:Bucket`), and that's what we trust by default.
+
+**Use `aws-native` when:**
+- The classic provider doesn't expose the resource (e.g. some recent AWS service launches).
+- The classic provider has a known import bug for that type (rare; document in the migration report when you hit one).
+- The user specifically requests it for downstream consistency.
+
+**Don't mix providers for the same logical resource.** If you migrate an S3 bucket via `aws.s3.Bucket`, don't migrate its policy as `aws-native.s3.BucketPolicy` — pick one provider per logical group.
+
+---
+
+## 5. CDK-synthesized stacks
+
+When the discovered CF stack was produced by AWS CDK, there are a few extra signals and patterns the agent should know. This section only applies to CDK stacks; plain CF stacks skip it.
+
+**Detection:** resources synthesized by CDK carry an `inputs.cdkPath` field in our API response (e.g. `CdkExampleStack-Dev/Messaging/SnsTopic/Resource`). If you see `cdkPath` on multiple resources, you're looking at a CDK-synthesized stack.
+
+### 5.1 `cdkPath` as a structural signal
+
+`cdkPath` is the CDK construct path. It's hierarchical and groups resources by the construct that created them. In Phase 7 (refactor) it's the most reliable way to find natural component boundaries:
+
+```
+CdkExampleStack-Dev/Messaging/SnsTopic/Resource    → group "Messaging"
+CdkExampleStack-Dev/Messaging/KinesisStream/Resource → group "Messaging"
+CdkExampleStack-Dev/Database/DbCluster/Resource    → group "Database"
+```
+
+Extract the group from the second path segment:
+
+```bash
+jq '[.resources[] | {name, group: (.resource.inputs.cdkPath // "" | split("/")[1] // "root")}] | group_by(.group)' \
+  .migration/resources-baseline.json
+```
+
+Use this when consolidating into ComponentResources or splitting into files — the CDK author already decided the boundaries, and the imported program should reflect them when that's what the user wants.
+
+### 5.2 CDK custom resources
+
+CDK uses Lambda-backed custom resources for things CloudFormation doesn't natively support. In our discovered data they appear as `AWS::CloudFormation::CustomResource` or `Custom::*`, often with a `cdkPath` like `aws-s3/auto-delete-objects-handler`. Many have native Pulumi replacements:
+
+| CDK handler | Pulumi replacement |
+|---|---|
+| `aws-certificatemanager/dns-validated-certificate-handler` | `aws.acm.Certificate` + `aws.route53.Record` + `aws.acm.CertificateValidation` |
+| `aws-ec2/restrict-default-security-group-handler` | `aws.ec2.DefaultSecurityGroup` with empty ingress/egress |
+| `aws-ecr/auto-delete-images-handler` | `aws.ecr.Repository` with `forceDelete: true` |
+| `aws-s3/auto-delete-objects-handler` | `aws.s3.Bucket` with `forceDestroy: true` |
+| `aws-s3/notifications-resource-handler` | `aws.s3.BucketNotification` |
+| `aws-logs/log-retention-handler` | `aws.cloudwatch.LogGroup` with `retentionInDays` |
+| `aws-iam/oidc-handler` | `aws.iam.OpenIdConnectProvider` |
+| `aws-route53/delete-existing-record-set-handler` | `aws.route53.Record` with `allowOverwrite: true` |
+| `aws-dynamodb/replica-handler` | `aws.dynamodb.TableReplica` |
+| `aws-cloudfront/edge-function` | `aws.lambda.Function` with `region: "us-east-1"` |
+
+**For unknown handlers:** surface to the user with a note describing what the handler does. Don't annotate `Migrated` without user confirmation — the custom resource may be doing something important. If the user wants the same behaviour, recommend the equivalent native resource and add it to the Pulumi program directly.
+
+**When the handler Lambda itself is deleted** (common for old stacks): the custom resource is dangling. Annotate `statusOverride=Migrated` with a note.
+
+---
+
+## 6. Common AWS diff patterns
+
+The generic removed/added/changed diagnostic workflow is in SKILL.md Phase 6. Below are AWS-specific patterns:
+
+- **Deprecated fields** — the classic provider sometimes generates deprecated property names (e.g. `is_enabled` instead of `state` on EventRule). Replace with the current equivalent.
+- **Missing optional blocks** — some resources import without sub-blocks that the provider expects (e.g. `destination_config` on event source mappings). Add the block with values from `aws describe-*`, or remove if truly optional.
+- **Provider-computed defaults** — fields like `recoveryWindowInDays`, `confirmationTimeoutInMinutes`, `forceOverwriteReplicaSecret` often differ between the provider default and the cloud value. Set explicitly in code, or `ignoreChanges` if genuinely provider-managed.
+- **Value range mismatches** — CF metadata can carry values outside the classic provider's accepted range. Verify against the actual resource state with `aws describe-*` and use the real value.
+
+---
+
+## 7. CF types with multiple Pulumi mappings
+
+A single CF type sometimes maps to several valid Pulumi classic types. Our discovery service picks a **primary** mapping, but it can be wrong for your specific resource. When `pulumi import` fails with a schema mismatch for a NotFound resource, consult this table before giving up — the alternative is often the right answer.
+
+| CF type | Primary (what the API returns) | Alternative | When to use the alternative |
+|---|---|---|---|
+| `AWS::EC2::VPCGatewayAttachment` | `aws:ec2/internetGatewayAttachment:InternetGatewayAttachment` | `aws:ec2/vpnGatewayAttachment:VpnGatewayAttachment` | attachment is a virtual private gateway (VGW) |
+| `AWS::EC2::VPCCidrBlock` | `aws:ec2/vpcIpv4CidrBlockAssociation:VpcIpv4CidrBlockAssociation` | `aws:ec2/vpcIpv6CidrBlockAssociation:VpcIpv6CidrBlockAssociation` | the associated block is IPv6 |
+| `AWS::RDS::DBInstance` | `aws:rds/instance:Instance` | `aws:rds/clusterInstance:ClusterInstance` | instance is a member of an Aurora cluster (writer/reader) |
+| `AWS::S3::Bucket` | `aws:s3/bucket:Bucket` | `aws:s3control/bucket:Bucket`, or any `aws:s3/bucket<Aspect>` resource | S3 on Outposts; or managing a single facet (ACL, CORS, lifecycle, logging, notification, versioning, website, replication, SSE, etc.) separately |
+| `AWS::S3::BucketPolicy` | `aws:s3/bucketPolicy:BucketPolicy` | `aws:s3control/bucketPolicy:BucketPolicy` | S3 on Outposts bucket policy |
+| `AWS::SES::ConfigurationSet` | `aws:sesv2/configurationSet:ConfigurationSet` | `aws:ses/configurationSet:ConfigurationSet` | existing code base uses SES v1 (legacy) |
+| `AWS::SES::EmailIdentity` | `aws:sesv2/emailIdentity:EmailIdentity` | `aws:ses/emailIdentity:EmailIdentity` | existing code base uses SES v1 (legacy) |
+| `AWS::APS::Workspace` | `aws:amp/workspace:Workspace` | `aws:amp/workspaceConfiguration:WorkspaceConfiguration` | managing per-workspace logging/labels as a separate resource |
+| `AWS::ElasticLoadBalancingV2::*` | `aws:lb/*` | `aws:alb/*` | `alb` is an alias of `lb` with identical behavior — only relevant when matching an existing code base |
+
+**Troubleshooting flow:** when a NotFound import fails with a schema mismatch or produces unexpected diffs:
+
+1. Look up the resource's `originType` in this table.
+2. If an alternative matches your scenario, override `providerType` in `import.json` and retry.
+3. A corrected mapping will appear as `PulumiOnly` on the next `compareTo`. Annotate the original NotFound as `statusOverride=Migrated` with `linkedResourceUrn` pointing to the PulumiOnly URN (see SKILL.md Phase 5).
+
+---
+
+## 8. Reading a CF template (refactor phase only)
+
+After Phase 6 (zero-diff achieved, PR created), if the user wants the imported program to *look* like the original CF/CDK code (component grouping, parameterization, references), the template is the reference. **This is optional polish, not part of the migration itself.**
+
+### CF intrinsic functions → Pulumi equivalents
+
+| CloudFormation | Pulumi |
+|---|---|
+| `!Ref <resource>` | resource output (e.g. `bucket.id`) |
+| `!Ref <param>` | Pulumi config (`config.require(...)`) |
+| `!GetAtt <resource>.<attr>` | resource property (e.g. `bucket.arn`) |
+| `!Sub "...${X}..."` | `pulumi.interpolate\`...${x}...\`` |
+| `!Join [delim, [...]]` | template literal or `.apply(parts => parts.join(delim))` |
+| `!If [cond, true, false]` | `cond ? a : b` |
+| `!Equals [a, b]` | `a === b` |
+| `!Select [idx, list]` | `list.apply(l => l[idx])` |
+| `!Split [delim, str]` | `str.apply(s => s.split(delim))` |
+| `Fn::ImportValue` | stack reference or config |
+
+### CF Parameters → Pulumi config
+
+```ts
+// CF: "Parameters": {"InstanceType": {"Type": "String", "Default": "t3.micro"}}
+const config = new pulumi.Config();
+const instanceType = config.get("instanceType") || "t3.micro";
+```
+
+### CF Mappings → TS objects
+
+```ts
+const regionMap: Record<string, {ami: string}> = {
+  "us-east-1": {ami: "ami-12345"},
+  "us-west-2": {ami: "ami-67890"},
+};
+const ami = regionMap[aws.config.region!].ami;
+```
+
+### CF Conditions → TS conditionals
+
+```ts
+const createProdResources = environment === "prod";
+if (createProdResources) {
+  // ...
+}
+```
+
+**Important:** the goal of the refactor phase is to make the program more maintainable, not to reproduce the template literally. Don't refactor away from a clean zero-diff state without re-validating with `pulumi preview` after each change.
+
+---
+
+## 9. Further reading
+
+- [Pulumi AWS provider](https://www.pulumi.com/registry/packages/aws/)
+- [Pulumi AWS Native provider](https://www.pulumi.com/registry/packages/aws-native/)
+- [Migrating to Pulumi from AWS](https://www.pulumi.com/docs/iac/adopting-pulumi/migrating-to-pulumi/from-aws/)
+- [Finding AWS import IDs](https://www.pulumi.com/docs/iac/guides/migration/aws-import-ids/)

--- a/migration/skills/pulumi-migrate-from-discovered-stack/refactor.md
+++ b/migration/skills/pulumi-migrate-from-discovered-stack/refactor.md
@@ -1,0 +1,126 @@
+# Post-Migration Refactor
+
+## The invariant
+
+**Zero-diff holds throughout the refactor, full stop.** After every edit, run `pulumi preview` and expect no changes.
+
+- **Make one small change at a time.** One resource's ARN replaced with a reference. One hardcoded region extracted into config. One group of resources moved into a file.
+- **Preview after every change.** If preview stays clean, commit and move on. If preview shows a diff, revert that single change before trying something else.
+- **Never run `pulumi up` to absorb a refactor diff.**
+
+---
+
+## Available signals
+
+Read these in priority order. The first signal that gives you enough information for a structural proposal to the user is where to pause and confirm. Remaining signals may be revisited during the actual refactor.
+
+**1. Original source code** — if the user provided a path/URL. **This is the primary structural reference.** Read it first, before looking at anything else:
+- Top-level file layout → informs how to split the Pulumi program into files.
+- Class/module/subdirectory names → suggest natural `ComponentResource` boundaries and file names.
+- Loops, reusable modules, naming conventions → guide how to group and parameterize in Pulumi.
+- Parameters/variables → suggest `pulumi.Config` key names.
+
+When a source repo is present, use it as the starting point for refactoring decisions, then adapt based on what the import model actually produced. The goal is recognizable and maintainable project structure.
+
+**2. The discovered-stacks API response** (on disk at `.migration/resources-baseline.json`):
+- `resource.parent` and `resource.dependencies[]` — explicit URN-level relationships. If `A`'s dependencies include `B`, `A` likely references `B`'s ARN/ID/name somewhere in its inputs.
+- `inputs.providerId` and `inputs._fingerprint` — the exact literal values hardcoded in the generated code. Build a map `{providerId|_fingerprint → resource.name}` once, then grep the code for those literals to find replacement sites.
+- For CDK-synthesized stacks, `inputs.cdkPath` gives natural component boundaries — see [`cloudformation.md §5`](cloudformation.md).
+
+**3. Original CF/ARM template** (always fetchable):
+- **CloudFormation:** `aws cloudformation get-template --region <r> --stack-name <cfn-stack> --query 'TemplateBody' --output json > .migration/template.json`
+- **ARM:** `az group export --name <rg> --output json > .migration/template.json`
+- Signals: parameters (→ `pulumi.Config`), conditionals (→ TS conditionals), cross-resource `!Ref`/`!GetAtt` (confirms interpolation targets).
+
+**4. Target repo layout** — if the user described a preferred layout.
+
+Confirm the chosen approach with the user before editing.
+
+---
+
+## Strategies
+
+Don't apply these rigidly. The real work is **finding natural isles** — groups of resources that clearly belong together — and refactoring within those. If the code is already reasonably clean, stop early.
+
+**A. Take structural inspiration from the source repo (when one is available).**
+
+Before touching anything, read the source repo and note its shape — don't copy it mechanically, but use it to answer: what groupings would be familiar to this team?
+
+1. Note the top-level file/directory structure. Use it as a rough guide for how to split the Pulumi program, not a template to reproduce exactly.
+2. For each major class or module the user would recognize (e.g. `NetworkStack`, `DatabaseCluster`, `IamRoles`), consider whether a `pulumi.ComponentResource` with a similar name and scope makes sense given the actual imported resources. If the grouping is natural, use it; if it's artificial, skip it.
+3. Borrow config parameter names from the source where the concepts match. Don't invent new names just to differ.
+
+Propose the structure to the user before writing any code: "Based on your source repo, I'm thinking of grouping resources into `network.ts`, `database.ts`, and `iam.ts` — does that match how your team thinks about this stack?"
+
+**B. Identify relationships and interpolation candidates.**
+
+```
+jq '[.resources[] | {
+  name,
+  providerId: .resource.inputs.providerId,
+  fingerprint: .resource.inputs._fingerprint,
+  parent: (.resource.parent // null),
+  deps: (.resource.dependencies // [])
+}]' .migration/resources-baseline.json > .migration/relationships.json
+```
+
+Build a map from literal ARNs/physical IDs to resource names. For every resource `A` that has `B` in its `dependencies`, look in `A`'s generated code for `B`'s `providerId` or `_fingerprint` literal — that's an interpolation site. Replace the string literal with `B.arn` / `B.id` / `pulumi.interpolate\`...${B.name}...\`` as appropriate. Preview after each replacement.
+
+**C. Extract obvious parameters.**
+
+Region, account ID, environment tag. One at a time, into `pulumi.Config`. Verify the config values reproduce the same literal strings that were in the code.
+
+**D. Replace structural hardcoded values using the CF/ARM template.**
+
+When the imported code has a computed value (e.g. `!Sub "${AWS::StackName}-bucket"` resolved to a literal), the template tells you what the original construction was. Replace the literal with the equivalent Pulumi expression. See [`cloudformation.md §8`](cloudformation.md) or [`arm.md §7`](arm.md) for intrinsic-function mappings.
+
+**E. Consolidate into ComponentResources — only where natural.**
+
+If the resources have a clear grouping (for CDK stacks this is `cdkPath` — see [`cloudformation.md §5`](cloudformation.md); for ARM it's nested templates) and that grouping makes sense in the user's context, wrap it as a `pulumi.ComponentResource`. Don't force it — many groupings in imported code are noise, not natural isles.
+
+**F. Split into files — after components, not before.**
+
+File splits are a *last* consideration. They're the lowest-value change on their own: the file a resource lives in has no semantic impact. Split only when the program exceeds ~1000 lines, there are clear natural isles, or the user has asked for a specific layout. When a source repo is available, let it inform this decision.
+
+**G. Parameterize for multi-env.**
+
+Once the single stack is clean, a sibling `prod` stack can be created from the same program. Out of scope for the migration — just note it as a follow-up.
+
+---
+
+## Post-refactor maintainability review
+
+After each meaningful refactor pass, **present the result to the user** before moving on. Don't just run preview and assume it's good — get explicit sign-off.
+
+**What to present:**
+
+1. A brief summary: "I made N changes — replaced M hardcoded ARNs with references, extracted K config keys, and grouped resources into X components."
+2. The module/file breakdown: "Your program now has `network.ts`, `database.ts`, and `iam.ts`. `index.ts` imports and wires them together."
+3. Any judgment calls you made: "I named the component `NetworkStack` to match your source repo's `NetworkStack` CDK class — let me know if you'd prefer something else."
+
+**Ask the user explicitly:** "Does this structure match how you'd expect to maintain this code?"
+
+If they say no, ask a follow-up: "What would you change?" Then make the adjustments and repeat the walkthrough. Keep iterating until they confirm it's right.
+
+**Never open the PR without this sign-off.** A zero-diff program the user doesn't recognize is not a successful migration.
+
+---
+
+## Template / source-code reading references
+
+- **CF intrinsic functions → Pulumi** (`!Ref`, `!Sub`, `!GetAtt`, `!If`, `!Select`, etc.): [`cloudformation.md §8`](cloudformation.md).
+- **CF Parameters / Mappings / Conditions → Pulumi**: [`cloudformation.md §8`](cloudformation.md).
+- **ARM expressions → Pulumi** (`parameters()`, `variables()`, `resourceId()`, `reference()`, `concat()`, `uniqueString()`, etc.): [`arm.md §7`](arm.md).
+- **ARM `copy` loops / `condition` / `dependsOn`**: [`arm.md §7`](arm.md).
+- **Nested templates → `ComponentResource`**: [`arm.md §7`](arm.md).
+- **CDK construct → Pulumi equivalents for custom resources**: [`cloudformation.md §5`](cloudformation.md).
+
+---
+
+## When to stop
+
+- The user has reviewed the code and confirmed it's maintainable.
+- The invested effort exceeds the remaining value (e.g. extracting a Component for a one-off resource is noise).
+- A refactor would require state surgery (`pulumi state rename`) — **stop and ask the user**, don't silently do it.
+
+Don't chase a 1:1 reproduction of the original template. The goal is a maintainable Pulumi program the user's team can work in confidently — not a line-by-line translation.

--- a/migration/skills/pulumi-migrate-from-discovered-stack/scripts/build_import.py
+++ b/migration/skills/pulumi-migrate-from-discovered-stack/scripts/build_import.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Build an import.json from a discovered-stacks resources response.
+
+Usage:
+    python3 build_import.py <resources-baseline.json> [output-path]
+
+Reads the saved API response and writes import.json containing all Ready
+resources (excluding those with annotation overrides). If output-path is
+omitted, writes to .migration/import.json relative to the baseline file.
+
+Field mapping:
+    type  ← providerType (top-level)
+    name  ← name (top-level, CF Logical ID / ARM name)
+    id    ← resource.inputs.providerId
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def effective_status(resource: dict[str, object]) -> str:
+    annotation = resource.get("annotation")
+    if isinstance(annotation, dict) and annotation.get("statusOverride"):
+        return str(annotation["statusOverride"])
+    return str(resource.get("migrationStatus", "Unknown"))
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(
+            f"Usage: {sys.argv[0]} <resources-baseline.json> [output-path]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    baseline_path = Path(sys.argv[1])
+    data = json.loads(baseline_path.read_text())
+    resources = data if isinstance(data, list) else data.get("resources", [])
+
+    output_path = (
+        Path(sys.argv[2]) if len(sys.argv) > 2 else baseline_path.parent / "import.json"
+    )
+
+    import_resources = []
+    skipped = {"no_provider_type": 0, "not_ready": 0, "overridden": 0}
+
+    for r in resources:
+        status = effective_status(r)
+        provider_type = r.get("providerType")
+        provider_id = (r.get("resource") or {}).get("inputs", {}).get("providerId")
+        name = r.get("name")
+
+        if not provider_type:
+            skipped["no_provider_type"] += 1
+            continue
+        if status not in ("Ready", "NotFound"):
+            skipped["not_ready"] += 1
+            continue
+        annotation = r.get("annotation")
+        if annotation and annotation.get("statusOverride") == "Migrated":
+            skipped["overridden"] += 1
+            continue
+        if not provider_id:
+            print(
+                f"WARNING: {name} has providerType but no providerId, skipping",
+                file=sys.stderr,
+            )
+            continue
+
+        import_resources.append(
+            {
+                "type": provider_type,
+                "name": name,
+                "id": provider_id,
+            }
+        )
+
+    import_json = {"resources": import_resources}
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(import_json, indent=2))
+
+    print(f"Wrote {len(import_resources)} resources to {output_path}")
+    if any(skipped.values()):
+        print(
+            f"Skipped: {skipped['not_ready']} not Ready/NotFound, "
+            f"{skipped['no_provider_type']} without a provider type, "
+            f"{skipped['overridden']} already annotated"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/skills/pulumi-migrate-from-discovered-stack/scripts/triage.py
+++ b/migration/skills/pulumi-migrate-from-discovered-stack/scripts/triage.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Triage a discovered-stacks resources response.
+
+Usage:
+    python3 triage.py <resources-baseline.json>
+
+Reads the saved API response and prints:
+- Status counts (accounting for annotation overrides)
+- Per-resource table with name, origin type, provider type, status, and annotation
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def effective_status(resource: dict[str, object]) -> str:
+    annotation = resource.get("annotation")
+    if isinstance(annotation, dict) and annotation.get("statusOverride"):
+        return str(annotation["statusOverride"])
+    return str(resource.get("migrationStatus", "Unknown"))
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <resources-baseline.json>", file=sys.stderr)
+        sys.exit(1)
+
+    data = json.loads(Path(sys.argv[1]).read_text())
+    resources = data if isinstance(data, list) else data.get("resources", [])
+
+    counts: dict[str, int] = {}
+    rows: list[dict[str, str]] = []
+
+    for r in resources:
+        status = effective_status(r)
+        counts[status] = counts.get(status, 0) + 1
+        annotation = r.get("annotation")
+        rows.append(
+            {
+                "name": r.get("name", ""),
+                "originType": r.get("originType", ""),
+                "providerType": r.get("providerType") or "(unmapped)",
+                "status": status,
+                "note": (annotation.get("note", "") if annotation else ""),
+            }
+        )
+
+    total = len(resources)
+    print(f"Total: {total} resources\n")
+    for status in [
+        "Migrated",
+        "Ready",
+        "NotFound",
+        "NoMatch",
+        "PulumiOnly",
+        "NotApplicable",
+    ]:
+        if status in counts:
+            print(f"  {status}: {counts[status]}")
+    for status in sorted(counts):
+        if status not in [
+            "Migrated",
+            "Ready",
+            "NotFound",
+            "NoMatch",
+            "PulumiOnly",
+            "NotApplicable",
+        ]:
+            print(f"  {status}: {counts[status]}")
+
+    print(f"\n{'Name':<55} {'Origin':<35} {'Provider':<35} {'Status':<15} Note")
+    print("-" * 160)
+    for row in sorted(rows, key=lambda r: (r["status"], r["name"])):
+        note = row["note"][:40] + "..." if len(row["note"]) > 40 else row["note"]
+        print(
+            f"{row['name']:<55} {row['originType']:<35} {row['providerType']:<35} {row['status']:<15} {note}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/skills/pulumi-migrate-from-discovered-stack/use_cases.yaml
+++ b/migration/skills/pulumi-migrate-from-discovered-stack/use_cases.yaml
@@ -1,0 +1,9 @@
+# Queries that should activate the pulumi-migrate-from-discovered-stack skill
+queries:
+  - "I have a discovered CloudFormation stack in Pulumi Cloud and want to migrate it to Pulumi"
+  - "Migrate my discovered ARM stack to a Pulumi project using the discovered-stacks API"
+  - "Help me import resources from a discovered stack into a new Pulumi stack"
+  - "Pulumi Cloud's Discovery feature found a CloudFormation stack in our account, bring it under Pulumi management"
+  - "We have a scanned/discovered stack in Pulumi Cloud Insights, migrate its resources to a real Pulumi stack"
+  - "Continue the discovered-stack migration we started last week and finish importing the remaining resources"
+  - "Use the discovered-stacks API to migrate this ARM deployment to Pulumi"


### PR DESCRIPTION

- Adds `pulumi-migrate-from-discovered-stack`, a new skill in the `migration` plugin group, alongside `pulumi-terraform-to-pulumi`, `pulumi-cdk-to-pulumi`, `cloudformation-to-pulumi`, and `pulumi-arm-to-pulumi`.
- Migrates a CloudFormation or ARM stack that Pulumi Cloud's Discovery feature has already scanned and exposed via the discovered-stacks API into a managed Pulumi stack. This is a **cloud-state-first** workflow (import from discovered state, then optional refactor against the original template) rather than the **template-first** workflow (mechanical translation → import) the two existing CF/ARM skills use — the skill explicitly says not to load them together.
- Adds `use_cases.yaml` and `agents/openai.yaml` following the conventions of the other migration skills, and updates `README.md` / `AGENTS.md`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)