### PR TITLE
Sync ARM resource-shape docs with resource-group-based discovery grouping

### DIFF
--- a/migration/skills/pulumi-migrate-from-discovered-stack/SKILL.md
+++ b/migration/skills/pulumi-migrate-from-discovered-stack/SKILL.md
@@ -58,12 +58,21 @@ The `resource.inputs` object also carries raw cloud-provider data:
 
 For CDK-synthesized CF stacks, `inputs.cdkPath` is also present — see [`cloudformation.md §5`](cloudformation.md) for how to use it.
 
-**For ARM** — `resource.inputs.arm`:
+**For ARM** — `resource.inputs.arm`. ARM resources are grouped by resource group, not by
+deployment, so a resource with no deployment currently backing it (its deployment history
+aged out of Azure's retention window, or it was created outside any tracked deployment) is
+still returned — just as a placeholder, with `resource.inputs.deploymentName` empty and a
+different `arm` shape:
 
--   `properties.targetResource.id` — the full Azure resource ID
--   `properties.targetResource.resourceType` — the ARM type
--   `properties.targetResource.resourceName` — the ARM resource name
--   `properties.provisioningState` — e.g. `Succeeded`
+-   **Deployment-backed** (`resource.inputs.deploymentName` non-empty) — `arm` is a
+    deployment-operation object: `properties.targetResource.id` / `.resourceType` /
+    `.resourceName`, `properties.provisioningState` (e.g. `Succeeded`).
+-   **Placeholder** (`resource.inputs.deploymentName` empty) — `arm` is the raw Azure
+    generic-resource object instead: top-level `id`, `name`, `type`, `location`, `tags`.
+    No `properties.targetResource` — don't look for it.
+
+Either way, prefer the top-level `resource.inputs.providerId` for the import ID (see
+above) rather than reaching into `arm` — it's already normalized across both shapes.
 
 ### Migration statuses
 
@@ -72,7 +81,7 @@ Statuses are PascalCase. First match wins:
 1. **`Migrated`** — the resource was found in the `compareTo` Pulumi stack. Already under Pulumi management; skip.
 2. **`Ready`** — `providerType` and `providerId` are set and the scanner confirmed the resource exists. Import with `pulumi import <providerType> <name> <providerId> --generate-code --out <file>.ts` (NEVER without `--generate-code --out` — see Phase 4).
 3. **`NotFound`** — `providerType` and `providerId` are set, but the scanner could not confirm the resource's current state. May be deleted, mapping may be imperfect, or scanner hit a gap. Verify before importing.
-4. **`NotApplicable`** — container or wrapper types (`AWS::CloudFormation::Stack`, `Microsoft.Resources/deployments`, `pulumi:providers:*`) are not individually migratable. Skip silently.
+4. **`NotApplicable`** — container or wrapper types (`AWS::CloudFormation::Stack`, `Microsoft.Resources/deployments`, `Microsoft.Resources/resourceGroups`, `pulumi:providers:*`) are not individually migratable. Skip silently.
 5. **`NoMatch`** — `providerType` is `null`. No mapping found. Common examples:
     - CF Custom Resources (e.g. `Custom::VpcRestrictDefaultSG`) — no direct Pulumi equivalent.
     - Inline policies — `AWS::IAM::Policy` modeled as an inline property of `aws:iam/role:Role`. Once the parent Role is migrated, annotate the policy as migrated.

--- a/migration/skills/pulumi-migrate-from-discovered-stack/arm.md
+++ b/migration/skills/pulumi-migrate-from-discovered-stack/arm.md
@@ -91,7 +91,7 @@ Child resources extend it:
 .../Microsoft.ApiManagement/service/{svc}/apis/{api}/operations/{op}/policies/policy
 ```
 
-Our API returns the full ID at `resource.inputs.arm.properties.targetResource.id` (or `resource.inputs.providerId`). Use that verbatim in the import file; don't reconstruct it by hand.
+Our API returns the full ID at `resource.inputs.providerId` — use that verbatim in the import file; don't reconstruct it by hand. `resource.inputs.arm.properties.targetResource.id` carries the same ID, but only when the resource currently has deployment metadata (`resource.inputs.deploymentName` non-empty); a placeholder resource (deployment history aged out of Azure's retention) has a different `arm` shape with no `properties.targetResource` — see SKILL.md's "For ARM" section. `providerId` works for both, so prefer it.
 
 ### Listing by type
 ```bash


### PR DESCRIPTION
`pulumi-migrate-from-discovered-stack` (#46/#47) was published before an internal change
(pulumi/pulumi-service#47223) started grouping discovered Azure/ARM resources by resource
group instead of by ARM deployment, and added a "placeholder" resource shape for resources
whose deployment history aged out of Azure's retention window. This left the skill's
description of `resource.inputs.arm` stale.

Ports the doc update: `SKILL.md`'s "For ARM" section now documents both the
deployment-backed and placeholder `arm` shapes and points at `providerId` as the
shape-independent import ID; `arm.md`'s import-ID section gets the same clarification.
No behavior/API change, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)