### PR TITLE
debug-failed-operation: surface a missing/blocked diagnostic to the user

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulumi",
   "displayName": "Pulumi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Teach your agent Pulumi: infrastructure as code in TypeScript, Python, Go, C#, Java, YAML, or HCL. Skills for writing and operating cloud infrastructure, migrating from Terraform, CloudFormation, CDK, and ARM, and delegating work to Pulumi Neo, Pulumi's AI platform engineer.",
   "author": {
     "name": "Pulumi",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Teach your agent Pulumi: infrastructure as code in TypeScript, Python, Go, C#, Java, YAML, or HCL. Skills for writing and operating cloud infrastructure, migrating from Terraform, CloudFormation, CDK, and ARM, and delegating work to Pulumi Neo, Pulumi's AI platform engineer.",
   "skills": [
     "./pulumi/skills",

--- a/pulumi/.claude-plugin/plugin.json
+++ b/pulumi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Entry-point and specialized skills for writing and operating Pulumi infrastructure across CLI, projects, and Pulumi Cloud",
   "author": {
     "name": "Pulumi",

--- a/pulumi/.codex-plugin/plugin.json
+++ b/pulumi/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Entry-point and specialized skills for writing and operating Pulumi infrastructure across CLI, projects, and Pulumi Cloud",
   "skills": "./skills/",
   "author": {

--- a/pulumi/skills/pulumi-debug-failed-operation/SKILL.md
+++ b/pulumi/skills/pulumi-debug-failed-operation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pulumi-debug-failed-operation
-version: 1.0.0
+version: 1.1.0
 description: |
     Debug a Pulumi update or preview that failed: read the failure Pulumi already
     recorded, find what caused it, and fix it. Load this skill when the user asks
@@ -64,6 +64,19 @@ error carries that `error` tag, but a program error, which is the common case wh
 a preview fails, arrives as a stderr diagnostic tagged `info#err`. The trailing
 `sed` strips terminal color codes that Pulumi embeds in the text, which otherwise
 show up as `<{%reset%}>`.
+
+## When the record has no readable error
+
+Sometimes the recorded diagnostic isn't enough to debug from — most often a bare
+`error: exit status 1` with no stderr. That happens when a resource shells out to
+an external builder or CLI (e.g. a `docker-build` `Image` built with `exec: true`,
+whose real build log lives in the external builder, not the update record). When
+the diagnostic carries no actionable error — or when repeated attempts to reach
+the real error keep failing on authentication or not-found (the external build
+logs need a token you don't have, a private CI run you can't fetch) — stop
+inferring and reach the user: say plainly that the update record has no readable
+error, name what you're blocked on and the one thing you need from them ("paste
+the Depot build log", "grant access to the GitHub Actions run").
 
 ## Find the cause and where the fix belongs
 

--- a/pulumi/skills/pulumi-debug-failed-operation/SKILL.md
+++ b/pulumi/skills/pulumi-debug-failed-operation/SKILL.md
@@ -65,18 +65,6 @@ a preview fails, arrives as a stderr diagnostic tagged `info#err`. The trailing
 `sed` strips terminal color codes that Pulumi embeds in the text, which otherwise
 show up as `<{%reset%}>`.
 
-## When you can't reach the real error, stop and ask
-
-Sometimes the recorded diagnostic isn't enough to debug from — for example a bare
-`error: exit status 1` with no stderr, which happens when a resource shells out to
-an external builder or CLI whose real log lives outside the update record. Don't
-spend iteration after iteration inferring the cause by archaeology. When the
-diagnostic carries no actionable error — or when repeated attempts to reach the
-real error keep failing (the log needs a token you don't have, a run you can't
-fetch, a not-found) — stop and reach the user instead of guessing again: say
-plainly that the record has no readable error, and name what you're blocked on and
-the one thing you need from them to get the actual log.
-
 ## Find the cause and where the fix belongs
 
 An operation can fail with errors from more than one resource, so read all of the
@@ -101,6 +89,15 @@ keeps you from editing code that was never the problem.
 - **The environment.** The problem is outside Pulumi: credentials, permissions,
   OIDC, or a quota. Fix the role, the ESC environment, or the capacity that the
   provider rejected, rather than the resource code.
+
+Sometimes the recorded diagnostic isn't enough to debug from — for example a bare
+`error: exit status 1` with no stderr, which happens when a resource shells out to
+an external builder or CLI whose real log lives outside the update record. Don't
+spend hundreds of iterations inferring the cause by archaeology. When repeated
+attempts to reach the real error keep failing (the log needs a token you don't
+have, a run you can't fetch, a not-found) — stop and reach the user instead of
+guessing again: say plainly that the record has no readable error, and name what
+you're blocked on and the one thing you need from them to get the actual log.
 
 ## Fix the cause
 

--- a/pulumi/skills/pulumi-debug-failed-operation/SKILL.md
+++ b/pulumi/skills/pulumi-debug-failed-operation/SKILL.md
@@ -65,18 +65,17 @@ a preview fails, arrives as a stderr diagnostic tagged `info#err`. The trailing
 `sed` strips terminal color codes that Pulumi embeds in the text, which otherwise
 show up as `<{%reset%}>`.
 
-## When the record has no readable error
+## When you can't reach the real error, stop and ask
 
-Sometimes the recorded diagnostic isn't enough to debug from — most often a bare
-`error: exit status 1` with no stderr. That happens when a resource shells out to
-an external builder or CLI (e.g. a `docker-build` `Image` built with `exec: true`,
-whose real build log lives in the external builder, not the update record). When
-the diagnostic carries no actionable error — or when repeated attempts to reach
-the real error keep failing on authentication or not-found (the external build
-logs need a token you don't have, a private CI run you can't fetch) — stop
-inferring and reach the user: say plainly that the update record has no readable
-error, name what you're blocked on and the one thing you need from them ("paste
-the Depot build log", "grant access to the GitHub Actions run").
+Sometimes the recorded diagnostic isn't enough to debug from — for example a bare
+`error: exit status 1` with no stderr, which happens when a resource shells out to
+an external builder or CLI whose real log lives outside the update record. Don't
+spend iteration after iteration inferring the cause by archaeology. When the
+diagnostic carries no actionable error — or when repeated attempts to reach the
+real error keep failing (the log needs a token you don't have, a run you can't
+fetch, a not-found) — stop and reach the user instead of guessing again: say
+plainly that the record has no readable error, and name what you're blocked on and
+the one thing you need from them to get the actual log.
 
 ## Find the cause and where the fix belongs
 


### PR DESCRIPTION
## What

Adds a **"When the record has no readable error"** section to the `pulumi-debug-failed-operation` skill (and bumps it to `1.1.0`).

## Why

The skill's core premise is: *"Pulumi recorded the error when the operation failed, so once you know which operation it is you can read the error from that record without running anything again."* That premise breaks when the only recorded diagnostic is a bare `error: exit status 1` — which happens when a resource shells out to an external builder or CLI (e.g. a `docker-build` `Image` built with `exec: true`, whose real build log lives in the external builder, not the update record).

A production Neo task hit exactly this (pulumi/pulumi-service#47660, PRODUCTION-NEO-S4): with nothing readable in the record and every fallback route to the real log auth-blocked, it spent 200 iterations / 33 min / 4.7M tokens inferring by archaeology and produced zero output.

## The change

The new section tells the agent: when the diagnostic carries no actionable error — or when repeated attempts to reach the real error keep failing on authentication or not-found — **stop inferring and reach the user**: say plainly that the record has no readable error, and name what it's blocked on and the one thing it needs (e.g. "paste the Depot build log", "grant access to the GitHub Actions run").

## Companion change

pulumi/pulumi-service#47919 adds an 80%-of-`max_iterations` reminder in the Neo agent loop so the model surfaces progress before exhausting the cap. This skill change and that one are the two Neo-side mitigations for #47660; the underlying `exec: true` diagnostic gap itself belongs in `pulumi/pulumi-docker-build`.

## Test

`tests/test_manifests.py` passes locally (no manifest pins the skill version). Selection/quality tests require an API key and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)