### PR TITLE
Build diagnostic lines with concatenation, not jq interpolation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulumi",
   "displayName": "Pulumi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Teach your agent Pulumi: infrastructure as code in TypeScript, Python, Go, C#, Java, YAML, or HCL. Skills for writing and operating cloud infrastructure, migrating from Terraform, CloudFormation, CDK, and ARM, and delegating work to Pulumi Neo, Pulumi's AI platform engineer.",
   "author": {
     "name": "Pulumi",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Teach your agent Pulumi: infrastructure as code in TypeScript, Python, Go, C#, Java, YAML, or HCL. Skills for writing and operating cloud infrastructure, migrating from Terraform, CloudFormation, CDK, and ARM, and delegating work to Pulumi Neo, Pulumi's AI platform engineer.",
   "skills": [
     "./pulumi/skills",

--- a/pulumi/.claude-plugin/plugin.json
+++ b/pulumi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Entry-point and specialized skills for writing and operating Pulumi infrastructure across CLI, projects, and Pulumi Cloud",
   "author": {
     "name": "Pulumi",

--- a/pulumi/.codex-plugin/plugin.json
+++ b/pulumi/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Entry-point and specialized skills for writing and operating Pulumi infrastructure across CLI, projects, and Pulumi Cloud",
   "skills": "./skills/",
   "author": {

--- a/pulumi/skills/pulumi-debug-failed-operation/SKILL.md
+++ b/pulumi/skills/pulumi-debug-failed-operation/SKILL.md
@@ -47,7 +47,7 @@ For a failed update, use the `update` path with the version number:
 
 ```
 pulumi api /api/stacks/{orgName}/{projectName}/{stackName}/update/<version>/events \
-  | jq -r '.events[].diagnosticEvent | select(. != null) | "[\(.severity)] \(.message)"' \
+  | jq -r '.events[].diagnosticEvent | select(. != null) | (.severity + " " + .message)' \
   | sed 's/<{%reset%}>//g'
 ```
 
@@ -55,7 +55,7 @@ For a failed preview, use the `preview` path with the preview id:
 
 ```
 pulumi api /api/stacks/{orgName}/{projectName}/{stackName}/preview/<preview-id>/events \
-  | jq -r '.events[].diagnosticEvent | select(. != null) | "[\(.severity)] \(.message)"' \
+  | jq -r '.events[].diagnosticEvent | select(. != null) | (.severity + " " + .message)' \
   | sed 's/<{%reset%}>//g'
 ```
 
@@ -64,6 +64,13 @@ error carries that `error` tag, but a program error, which is the common case wh
 a preview fails, arrives as a stderr diagnostic tagged `info#err`. The trailing
 `sed` strips terminal color codes that Pulumi embeds in the text, which otherwise
 show up as `<{%reset%}>`.
+
+Build the line with `+` concatenation rather than jq string interpolation
+(`"[\(.severity)] \(.message)"`). The interpolation form reads better, but its
+backslashes have to survive being encoded into a JSON tool-call argument, and they
+often do not: the backslash arrives doubled, jq then treats it as an escaped literal,
+and every line of output comes back as the format string itself rather than the
+diagnostic. Concatenation needs no backslashes, so there is nothing to mis-escape.
 
 ## Find the cause and where the fix belongs
 


### PR DESCRIPTION
## Problem

The `pulumi-debug-failed-operation` skill's headline recipe extracts diagnostic messages from an update's engine events with jq string interpolation:

```
jq -r '.events[].diagnosticEvent | select(. != null) | "[\(.severity)] \(.message)"'
```

Those backslashes have to survive being encoded into a JSON tool-call argument, and often they don't. The backslash arrives doubled, jq reads `\\(` as an escaped literal rather than an interpolation, and every output line comes back as the format string itself:

```
[\(.severity)] \(.message)
[\(.severity)] \(.message)
...
```

The agent gets no diagnostics at all — just N copies of its own format string — and has to notice and rewrite the command before it can start debugging.

## Fix

Use `+` concatenation, which needs no backslashes, so there is nothing to mis-escape.

Verified both directions locally:

```
$ jq -r '.events[].diagnosticEvent | select(. != null) | (.severity + " " + .message)' t.json
error boom
info

$ jq -r '... | "[\\(.severity)] \\(.message)"' t.json   # as the model emits it
[\(.severity)] \(.message)
[\(.severity)] \(.message)
```

It also degrades gracefully: jq treats `null + " "` as `" "`, so a diagnostic with no message prints its severity rather than dropping the line.

Added a short note under the snippets explaining why, so the more readable interpolation form doesn't get restored later.

## Also

Patch-bumped `pulumi` (1.0.0 → 1.0.1) and the root combined manifests (2.0.0 → 2.0.1) in both ecosystem manifests, per AGENTS.md step 7.

## Testing

- `pytest tests/test_manifests.py` — 12 passed
- `pytest tests/test_skill_quality.py` — 16 failed, but on `main` as well and for every skill including untouched ones: `TypeError: Could not resolve authentication method` (no `ANTHROPIC_API_KEY` in my environment). Not exercised by this change.

## Out of scope

While measuring this I also found the `/events` path can be swamped by `info`-severity build output — in one real task `grep -i error` over it matched only Stencil lint warnings while the actual `docker-build` failures never appeared. That interacts with the deliberate "read every message, not only `severity == error`" guidance directly above these snippets, so it wants its own discussion rather than a drive-by change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)