### PR TITLE
debug-failed-operation: condense the missing-diagnostic guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulumi",
   "displayName": "Pulumi",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Teach your agent Pulumi: infrastructure as code in TypeScript, Python, Go, C#, Java, YAML, or HCL. Skills for writing and operating cloud infrastructure, migrating from Terraform, CloudFormation, CDK, and ARM, and delegating work to Pulumi Neo, Pulumi's AI platform engineer.",
   "author": {
     "name": "Pulumi",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Teach your agent Pulumi: infrastructure as code in TypeScript, Python, Go, C#, Java, YAML, or HCL. Skills for writing and operating cloud infrastructure, migrating from Terraform, CloudFormation, CDK, and ARM, and delegating work to Pulumi Neo, Pulumi's AI platform engineer.",
   "skills": [
     "./pulumi/skills",

--- a/pulumi/.claude-plugin/plugin.json
+++ b/pulumi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Entry-point and specialized skills for writing and operating Pulumi infrastructure across CLI, projects, and Pulumi Cloud",
   "author": {
     "name": "Pulumi",

--- a/pulumi/.codex-plugin/plugin.json
+++ b/pulumi/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Entry-point and specialized skills for writing and operating Pulumi infrastructure across CLI, projects, and Pulumi Cloud",
   "skills": "./skills/",
   "author": {

--- a/pulumi/skills/pulumi-debug-failed-operation/SKILL.md
+++ b/pulumi/skills/pulumi-debug-failed-operation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pulumi-debug-failed-operation
-version: 1.1.0
+version: 1.1.1
 description: |
     Debug a Pulumi update or preview that failed: read the failure Pulumi already
     recorded, find what caused it, and fix it. Load this skill when the user asks
@@ -90,14 +90,10 @@ keeps you from editing code that was never the problem.
   OIDC, or a quota. Fix the role, the ESC environment, or the capacity that the
   provider rejected, rather than the resource code.
 
-Sometimes the recorded diagnostic isn't enough to debug from — for example a bare
-`error: exit status 1` with no stderr, which happens when a resource shells out to
-an external builder or CLI whose real log lives outside the update record. Don't
-spend hundreds of iterations inferring the cause by archaeology. When repeated
-attempts to reach the real error keep failing (the log needs a token you don't
-have, a run you can't fetch, a not-found) — stop and reach the user instead of
-guessing again: say plainly that the record has no readable error, and name what
-you're blocked on and the one thing you need from them to get the actual log.
+When a diagnostic is empty or too thin to act on, the real error usually isn't in
+the record — it's in the log of whatever the resource shelled out to. Read it
+there. If reaching it needs access you don't have (a token, a run, a not-found),
+stop and tell the user what you're blocked on and the one thing you need from them.
 
 ## Fix the cause
 


### PR DESCRIPTION
Follow-up to #52. In the review thread on that PR, the missing/blocked-diagnostic paragraph was flagged as too wordy and prohibition-first. This condenses it to the wording agreed in the thread ([discussion](https://github.com/pulumi/agent-skills/pull/52#discussion_r3782935360)), with the specific tool examples removed to avoid overfitting per @flostadler's [feedback](https://github.com/pulumi/agent-skills/pull/52#discussion_r3783728730).

### Before
> Sometimes the recorded diagnostic isn't enough to debug from — for example a bare `error: exit status 1` with no stderr, which happens when a resource shells out to an external builder or CLI whose real log lives outside the update record. Don't spend hundreds of iterations inferring the cause by archaeology. When repeated attempts to reach the real error keep failing (the log needs a token you don't have, a run you can't fetch, a not-found) — stop and reach the user instead of guessing again: say plainly that the record has no readable error, and name what you're blocked on and the one thing you need from them to get the actual log.

### After
> When a diagnostic is empty or too thin to act on, the real error usually isn't in the record — it's in the log of whatever the resource shelled out to. Read it there. If reaching it needs access you don't have (a token, a run, a not-found), stop and tell the user what you're blocked on and the one thing you need from them.

The rewrite keeps the behavior everyone agreed on — try to reach the real log first, and only escalate when it's genuinely out of reach — but leads with *why* guessing fails instead of a prohibition, and no longer names specific tools.

### Versioning
Per AGENTS.md, a shipped-skill edit bumps the containing plugin manifests plus the root combined manifests:
- `pulumi/.claude-plugin/plugin.json` and `pulumi/.codex-plugin/plugin.json`: 1.0.1 → 1.0.2
- root `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`: 2.0.1 → 2.0.2
- skill frontmatter: 1.1.0 → 1.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)